### PR TITLE
Refactor Kubernetes Service Account to genai/common

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,10 +123,10 @@ Switch to the `genai` directory
 cd $CUR_DIR/genai
 ```
 
-Set kubernetes manifests for GenAI workloads to use your unique project id
+Set common kubernetes manifests for GenAI workloads to use your unique project id
 
 ```
-find . -type f -name "*.yaml" -exec sed -i "s:your-unique-project-id:$PROJECT_ID:g" {} +
+find common -type f -name "*.yaml" -exec sed -i "s:your-unique-project-id:$PROJECT_ID:g" {} +
 ```
 
 Build and run GenAI workloads with **Skaffold**

--- a/examples/friendschat/skaffold.yaml
+++ b/examples/friendschat/skaffold.yaml
@@ -46,5 +46,5 @@ deploy:
       global:
       - --namespace=genai
 requires:
-- configs: ["common-k8s-cfg","common-otel-cfg"]
+- configs: ["common"]
   path: ../../genai/common/skaffold.yaml

--- a/genai/api/genai_api/skaffold.yaml
+++ b/genai/api/genai_api/skaffold.yaml
@@ -32,5 +32,5 @@ deploy:
       global:
       - --namespace=genai
 requires:
-- configs: ["common-k8s-cfg","common-otel-cfg"]
+- configs: ["common"]
   path: ../../common/skaffold.yaml

--- a/genai/api/stable_diffusion_api/skaffold.yaml
+++ b/genai/api/stable_diffusion_api/skaffold.yaml
@@ -32,5 +32,5 @@ deploy:
       global:
       - --namespace=genai
 requires:
-- configs: ["common-k8s-cfg","common-otel-cfg"]
+- configs: ["common"]
   path: ../../common/skaffold.yaml

--- a/genai/api/vertex_chat_api/k8s.yaml
+++ b/genai/api/vertex_chat_api/k8s.yaml
@@ -1,10 +1,3 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  annotations:
-    iam.gke.io/gcp-service-account: sa-gke-aiplatform@your-unique-project-id.iam.gserviceaccount.com
-  name: k8s-sa-aiplatform
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/genai/api/vertex_chat_api/skaffold.yaml
+++ b/genai/api/vertex_chat_api/skaffold.yaml
@@ -32,5 +32,5 @@ deploy:
       global:
       - --namespace=genai
 requires:
-- configs: ["common-k8s-cfg","common-otel-cfg"]
+- configs: ["common"]
   path: ../../common/skaffold.yaml

--- a/genai/api/vertex_code_api/k8s.yaml
+++ b/genai/api/vertex_code_api/k8s.yaml
@@ -1,10 +1,3 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  annotations:
-    iam.gke.io/gcp-service-account: sa-gke-aiplatform@your-unique-project-id.iam.gserviceaccount.com
-  name: k8s-sa-aiplatform
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/genai/api/vertex_code_api/skaffold.yaml
+++ b/genai/api/vertex_code_api/skaffold.yaml
@@ -32,5 +32,5 @@ deploy:
       global:
       - --namespace=genai
 requires:
-- configs: ["common-k8s-cfg","common-otel-cfg"]
+- configs: ["common"]
   path: ../../common/skaffold.yaml

--- a/genai/api/vertex_gemini_api/skaffold.yaml
+++ b/genai/api/vertex_gemini_api/skaffold.yaml
@@ -32,5 +32,5 @@ deploy:
       global:
       - --namespace=genai
 requires:
-- configs: ["common-k8s-cfg","common-otel-cfg"]
+- configs: ["common"]
   path: ../../common/skaffold.yaml

--- a/genai/api/vertex_image_api/k8s.yaml
+++ b/genai/api/vertex_image_api/k8s.yaml
@@ -1,10 +1,3 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  annotations:
-    iam.gke.io/gcp-service-account: sa-gke-aiplatform@your-unique-project-id.iam.gserviceaccount.com
-  name: k8s-sa-aiplatform
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/genai/api/vertex_image_api/skaffold.yaml
+++ b/genai/api/vertex_image_api/skaffold.yaml
@@ -32,5 +32,5 @@ deploy:
       global:
       - --namespace=genai
 requires:
-- configs: ["common-k8s-cfg","common-otel-cfg"]
+- configs: ["common"]
   path: ../../common/skaffold.yaml

--- a/genai/api/vertex_text_api/k8s.yaml
+++ b/genai/api/vertex_text_api/k8s.yaml
@@ -1,10 +1,3 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  annotations:
-    iam.gke.io/gcp-service-account: sa-gke-aiplatform@your-unique-project-id.iam.gserviceaccount.com
-  name: k8s-sa-aiplatform
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/genai/api/vertex_text_api/skaffold.yaml
+++ b/genai/api/vertex_text_api/skaffold.yaml
@@ -32,5 +32,5 @@ deploy:
       global:
       - --namespace=genai
 requires:
-- configs: ["common-k8s-cfg","common-otel-cfg"]
+- configs: ["common"]
   path: ../../common/skaffold.yaml

--- a/genai/common/k8s-sa-aiplatform.yaml
+++ b/genai/common/k8s-sa-aiplatform.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: sa-gke-aiplatform@your-unique-project-id.iam.gserviceaccount.com
+  name: k8s-sa-aiplatform

--- a/genai/common/opentelemetry/k8s-sa-telemetry.yaml
+++ b/genai/common/opentelemetry/k8s-sa-telemetry.yaml
@@ -1,0 +1,7 @@
+# ServiceAccount kept separately to allow for .gitignore of modified project
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: sa-gke-telemetry@your-unique-project-id.iam.gserviceaccount.com
+  name: k8s-sa-telemetry

--- a/genai/common/opentelemetry/otel-collector.yaml
+++ b/genai/common/opentelemetry/otel-collector.yaml
@@ -1,9 +1,3 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  annotations:
-    iam.gke.io/gcp-service-account: sa-gke-telemetry@your-unique-project-id.iam.gserviceaccount.com
-  name: k8s-sa-telemetry
 
 ---
 apiVersion: opentelemetry.io/v1alpha1

--- a/genai/common/skaffold.yaml
+++ b/genai/common/skaffold.yaml
@@ -25,9 +25,26 @@ deploy:
 apiVersion: skaffold/v3
 kind: Config
 metadata:
+  name: common-k8s-sa-aiplatform
+manifests:
+  rawYaml:
+  - ./k8s-sa-aiplatform.yaml
+deploy:
+  kubectl:
+    flags:
+      global:
+      - --namespace=genai
+requires:
+- configs: ["common-k8s-cfg"]
+  path: skaffold.yaml
+---
+apiVersion: skaffold/v3
+kind: Config
+metadata:
   name: common-otel-cfg
 manifests:
   rawYaml:
+  - ./opentelemetry/k8s-sa-telemetry.yaml
   - ./opentelemetry/otel-collector.yaml
   - ./opentelemetry/genai-inst.yaml
 deploy:
@@ -37,4 +54,12 @@ deploy:
       - --namespace=genai
 requires:
 - configs: ["common-k8s-cfg"]
+  path: skaffold.yaml
+---
+apiVersion: skaffold/v3
+kind: Config
+metadata:
+  name: common
+requires:
+- configs: ["common-k8s-cfg","common-k8s-sa-aiplatform","common-otel-cfg"]
   path: skaffold.yaml


### PR DESCRIPTION
This PR resolves a workflow issue for me iterating on this repo: the `sed` to template the project for the KSA->SA mapping is kind of obnoxious from a `git` perspective.

Instead moves common KSA to a new module in common and introduces a "common" module that pulls all the common deps.

This doesn't make the files ignored since they're still tracked, but it does mean you can just avoid adding them to commits.