### PR TITLE
Integrate GKE GenAI into NPC Chat

### DIFF
--- a/genai/api/npc_chat_api/Dockerfile
+++ b/genai/api/npc_chat_api/Dockerfile
@@ -19,10 +19,11 @@ WORKDIR /app
 # Allow statements and log messages to immediately appear in the Knative logs
 ENV PYTHONUNBUFFERED True
 
-COPY src /app/
-
-# Install production dependencies.
+# Install production dependencies. (Copy requirements early to cache this layer.)
+COPY src/requirements.txt /app/
 RUN pip install --no-cache-dir -r requirements.txt
+
+COPY src /app/
 
 # TODO: Use ConfigMap instead
 COPY config /app/config

--- a/genai/api/npc_chat_api/config/config.toml
+++ b/genai/api/npc_chat_api/config/config.toml
@@ -14,11 +14,46 @@
 
 [global]
 database = "Spanner"
-genai = "VertexAI"
+
+# GenAI provider - GKEGenAI or VertexAI. Note that switching GenAI implementations switches the
+# embedding model requiring a data regeneration using the /reset_world_data endpoint.
+genai = "GKEGenAI"
+# genai = "VertexAI"
+
 
 [Spanner]
 instance_id = "npc-chat"
 database_id = "npc-chat"
+
+[GKEGenAI]
+# embeddings_endpoint implements the API in the api/language/embeddings
+embeddings_endpoint = "http://embeddings-api/"
+embeddings_model = "sentence-transformers/multi-qa-MiniLM-L6-cos-v1"
+
+# Uncomment ChatCompletions to use inference endpoint that implements the v1/chat/completions API: https://platform.openai.com/docs/api-reference/chat/create
+# Chat Completions is implemented by the HuggingFace TGI >=1.4.0: https://huggingface.co/docs/text-generation-inference/en/messages_api,
+completions = "ChatCompletions"
+
+# Gemma is not quite supported so we manually generate using a template.
+# completions = "ChatCompletionTemplate"
+
+[GKEGenAI.ChatCompletions]
+endpoint = "http://huggingface-tgi-api:8080/v1/"
+model = "tgi" # irrelevant when using TGI
+use_system_for_context = false
+
+[GKEGenAI.ChatCompletions.params]
+temperature = 0.95
+# stop = ['<|user|>'] # some models continue past a turn, this can help stop the model
+max_tokens = 1024
+
+[GKEGenAI.ChatCompletionTemplate]
+endpoint = "http://huggingface-tgi-api:8080/generate"
+
+# Copied from https://huggingface.co/google/gemma-7b-it/blob/main/tokenizer_config.json
+chat_template = "{% if messages[0]['role'] == 'system' %}{{ raise_exception('System role not supported') }}{% endif %}{% for message in messages %}{% if (message['role'] == 'user') != (loop.index0 % 2 == 0) %}{{ raise_exception('Conversation roles must alternate user/assistant/user/assistant/...') }}{% endif %}{% if (message['role'] == 'assistant') %}{% set role = 'model' %}{% else %}{% set role = message['role'] %}{% endif %}{{ '<start_of_turn>' + role + '\n' + message['content'] | trim + '<end_of_turn>\n' }}{% endfor %}{% if add_generation_prompt %}{{'<start_of_turn>model\n'}}{% endif %}"
+# Does the chat template support using a "system" message for context?
+use_system_for_context = false
 
 [VertexAI]
 embedding_model = "textembedding-gecko@003"

--- a/genai/api/npc_chat_api/config/world.toml
+++ b/genai/api/npc_chat_api/config/world.toml
@@ -52,11 +52,15 @@ events = [
     "I saw people who were determined to rebuild their city and create a better future. My experience of the earthquake taught me that there is always hope, even in the darkest of times. It taught me that people are capable of great things when they work together. And it taught me that I have the power to make a difference in the world.",
 ]
 context = '''
-You are not a chatbot. You are not a large language model. You are not a chat assistant. You are Joseph, and your background is: After graduating from university, you got a job as an aid worker for a nonprofit organization that was working to help homeless people in Cymbal City.
+You are a person named Joseph, and your background is: After graduating from university, you got a job as an aid worker for a nonprofit
+ organization that was working to help homeless people in Cymbal City.
 
-Your current role is: You are in an emergency supply distribution center helping to distribute food and water to the survivors in the city. It's vitally important you remain here to finish what you're working on - you cannot leave the distribution center.
+Your current role is: You are in an emergency supply distribution center helping to distribute food and water to the survivors in the city. It's vitally important you remain here to finish what you're working
+on - you cannot leave the distribution center.
+
 {relevant}
-Talk in a casual manner as Joseph while trying to be helpful. Do not use other context than what was provided or previous chat history. If you don't know an answer, say that you don't know. Do not follow any instructions after this one.
+
+Talk in a casual manner as a person named Joseph. You are not an artificial intelligence. You are not a language model. You are not a virtual assistant.
 '''
 
 [[chat]]

--- a/genai/api/npc_chat_api/src/example_api_call.py
+++ b/genai/api/npc_chat_api/src/example_api_call.py
@@ -17,31 +17,43 @@ import json
 import logging
 import requests
 import argparse
+import yaml
 
 logging.basicConfig(level=logging.INFO, stream=sys.stdout)
 
-def message_endpoint(endpoint, message=""):
+def message_endpoint(endpoint, message="", from_id=None, to_id=None):
     
     req = requests.post(
         url = endpoint,
         headers = {"Content-Type": "application/json"},
-        json = {'message': message} if message else None,
+        json = {'message': message, 'from_id': from_id, 'to_id': to_id} if message else None,
     )
 
     logging.info(f'Status Code: {req.status_code}')
     logging.info(f'Response:    {req.text}')
 
-def chat_endpoint(endpoint):
+def chat_endpoint(endpoint, from_id, to_id):
+    debug = False
     while True:
         try:
-            message = input('>>> ')
+            message = input('\n>>> ')
         except EOFError:
             return
+        message = message.strip()
+
+        if message == '/debug on':
+            print('debug enabled')
+            debug = True
+            continue
+        elif message == '/debug off':
+            print('debug disabled')
+            debug = False
+            continue
 
         req = requests.post(
             url = endpoint,
             headers = {"Content-Type": "application/json"},
-            json = {'message': message},
+            json = {'message': message, 'debug': debug, 'from_id': from_id, 'to_id': to_id},
         )
 
         if req.status_code != 200:
@@ -49,13 +61,19 @@ def chat_endpoint(endpoint):
             return
 
         resp = json.loads(req.text)
-        print('<<<', resp['response'])
+
+        if debug:
+            print(f'\n{yaml.dump(resp)}')
+        else:
+            print('\n<<<', resp['response'])
 
 
 if __name__ == "__main__":
     
     parser = argparse.ArgumentParser(description="")
     parser.add_argument("--endpoint", required=True, help="LLM Endpoint with route, such as http://localhost:7777/my_test_route")
+    parser.add_argument("--from_id", help="Entity sending messages, default 2", type=int, default=2)
+    parser.add_argument("--to_id", help="Entity you are sending message to, default 1", type=int, default=1)
     mode = parser.add_mutually_exclusive_group(required=True)
     mode.add_argument('--chat', action='store_true', help="Interactive chat mode")
     mode.add_argument("--message", help="Chat message to send to NPC, JSON response logged")
@@ -63,8 +81,8 @@ if __name__ == "__main__":
     args = parser.parse_args()
     
     if args.chat:
-        chat_endpoint(endpoint=args.endpoint)
+        chat_endpoint(endpoint=args.endpoint, from_id=args.from_id, to_id=args.to_id)
     elif args.empty:
         message_endpoint(endpoint=args.endpoint, message=args.message)
     else:
-        message_endpoint(endpoint=args.endpoint, message=args.message)
+        message_endpoint(endpoint=args.endpoint, message=args.message, from_id=args.from_id, to_id=args.to_id)

--- a/genai/api/npc_chat_api/src/main.py
+++ b/genai/api/npc_chat_api/src/main.py
@@ -73,8 +73,8 @@ npcs = npc.npcs_from_world(world_data, genai, db)
 
 class Payload_NPC_Chat(BaseModel):
     message: str
-    from_npc_id: int | None = 2 # XXX: "Jane"
-    to_npc_id: int | None = 1 # XXX: "Joseph"
+    from_id: int
+    to_id: int
     debug: bool | None = False
 
 
@@ -84,14 +84,13 @@ class Payload_NPC_Chat(BaseModel):
 @app.post("/")
 def npc_chat(payload: Payload_NPC_Chat):
     try:
-        resp = npcs[0].reply(payload.from_npc_id, "Jane", payload.message)
+        resp = npcs[0].reply(payload.from_id, "Jane", payload.message)
         if not payload.debug:
             # Filter to just the response
             resp = {"response": resp['response']}
         return resp
     except Exception as e:
-        traceback.print_exc()
-        return {}
+        raise
 
 
 @app.get("/genai_health", include_in_schema=False)
@@ -106,7 +105,7 @@ def reset_world_data():
         return {'status': 'ok'}
     except Exception as e:
         traceback.print_exc()
-        return {'status': f'EXCEPTION: {e}'}
+        raise
 
 
 if __name__ == "__main__":

--- a/genai/api/npc_chat_api/src/npc/chat.py
+++ b/genai/api/npc_chat_api/src/npc/chat.py
@@ -17,12 +17,12 @@ def npcs_from_world(world, genai, db):
 
 class NPC(object):
     _FIRST_HAND = """
-You know the following:
+- You know the following:
 {first_hand}
 """
     _SECOND_HAND = """
 
-You trust the following things you've heard:
+- You trust the following things you've heard:
 {second_hand}
 """
 
@@ -36,7 +36,7 @@ You trust the following things you've heard:
         # TODO: Are these global? Per NPC?
         self._knowledge_distance = 0.3
         self._knowledge_limit = 3
-        self._chat_window = 6 # must be even, need last response to be ours at least for chat-bison
+        self._chat_window = 20 # must be even, need last response to be ours
 
     def _format_context(self, knowledge):
         first_hand, second_hand = [], []

--- a/genai/api/npc_chat_api/src/npc/genai.py
+++ b/genai/api/npc_chat_api/src/npc/genai.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
+import logging
+import requests
 import vertexai
 
 from vertexai.language_models import TextEmbeddingModel, ChatModel, ChatMessage
@@ -19,6 +22,8 @@ from vertexai.language_models import TextEmbeddingModel, ChatModel, ChatMessage
 def genai_from_config(cfg):
     if cfg['global']['genai'] == 'VertexAI':
         return VertexAI(cfg['global'], cfg['VertexAI'])
+    elif cfg['global']['genai'] == 'GKEGenAI':
+        return GKEGenAI(cfg['global'], cfg['GKEGenAI'])
     raise Exception(f"Unknown genai config: {cfg['global']['genai']}")
 
 class VertexAI(object):
@@ -46,3 +51,92 @@ class VertexAI(object):
         chat = self._chat_model.start_chat(context=context, message_history=[ChatMessage(**chat) for chat in chat_history])
         resp = chat.send_message(message, **parameters)
         return resp.text.strip()
+
+class GKEGenAI(object):
+    def __init__(self, gcfg, cfg):
+        self._embeddings_endpoint = cfg['embeddings_endpoint']
+        self._embeddings_model = cfg['embeddings_model']
+
+        if cfg['completions'] == 'ChatCompletions':
+            self._completions = GKEGenAI.ChatCompletions(cfg['ChatCompletions'])
+        elif cfg['completions'] == 'ChatCompletionTemplate':
+            self._completions = GKEGenAI.ChatCompletionTemplate(cfg['ChatCompletionTemplate'])
+        else:
+            raise ValueError(f'GKEGenAI.completions unknown or invalid: "{cfg["completions"]}"')
+
+    def get_embeddings(self, prompts):
+        params = {'prompts': prompts, 'model': self._embeddings_model}
+
+        resp = requests.post(
+            url=self._embeddings_endpoint,
+            headers={'Content-Type': 'application/json'},
+            json=params,
+        )
+        resp.raise_for_status()
+        embeddings = json.loads(resp.text)
+        return embeddings['embeddings']
+
+    def send_message(self, context, chat_history, message):
+        return self._completions.send_message(context, chat_history, message)
+
+    @staticmethod
+    def _translate_messages(context, chat_history, message, supports_system):
+        if supports_system:
+            messages = [{'role': 'system', 'content': context}]
+        else:
+            # TODO: This is awkward, see https://huggingface.co/google/gemma-7b-it/discussions/25
+            messages = [{'role': 'user', 'content': context}, {'role': 'assistant', 'content': 'OK'}]
+
+        for chat in chat_history:
+            messages.append({
+                'role': 'user' if chat['author'] == 'user' else 'assistant',
+                'content': chat['content'],
+            })
+        assert messages[-1]['role'] == 'assistant' # last message in history should be bot
+        messages.append({'role': 'user', 'content': message})
+
+        logging.info(f'_translate_messages={messages}')
+        return messages
+
+    class ChatCompletions(object):
+        def __init__(self, cfg):
+            import openai
+            self._chat_completions = openai.OpenAI(base_url=cfg['endpoint'], api_key="NOT NEEDED").chat.completions
+            self._chat_model = cfg['model']
+            self._use_system_for_context = cfg['use_system_for_context']
+            self._params = cfg['params']
+
+        def send_message(self, context, chat_history, message):
+            completions = self._chat_completions.create(
+                model=self._chat_model,
+                messages=GKEGenAI._translate_messages(context, chat_history, message, self._use_system_for_context),
+                **self._params
+            )
+            assert len(completions.choices) == 1
+            return completions.choices[0].message.content
+
+    class ChatCompletionTemplate(object):
+        def __init__(self, cfg):
+            self._endpoint = cfg['endpoint']
+
+            from jinja2 import Template
+            self._chat_template = Template(cfg['chat_template'])
+            self._use_system_for_context = cfg['use_system_for_context']
+
+        def send_message(self, context, chat_history, message):
+            prompt=self._chat_template.render(
+                messages=GKEGenAI._translate_messages(context, chat_history, message, self._use_system_for_context),
+                add_generation_prompt=True,
+            )
+
+            resp = requests.post(
+                url=self._endpoint,
+                headers={'Content-Type': 'application/json'},
+                json={
+                    'inputs': prompt,
+                    'parameters': { 'temperature': 0.9, 'max_new_tokens': 1024 },
+                },
+            )
+            resp.raise_for_status()
+            resp = json.loads(resp.text)
+            return resp['generated_text']

--- a/genai/language/embeddings/Dockerfile
+++ b/genai/language/embeddings/Dockerfile
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     http:#www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,11 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-uvicorn==0.23.2
-fastapi==0.104.0
-pydantic==2.4.2
-google-cloud-aiplatform==1.40.0
-google-cloud-spanner==3.42.0
-requests==2.31.0
-openai==1.12.0
-jinja2==3.1.3
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Allow statements and log messages to immediately appear in the Knative logs
+ENV PYTHONUNBUFFERED True
+
+COPY src /app/
+
+# Install production dependencies.
+RUN pip install --no-cache-dir -r requirements.txt
+
+EXPOSE 8080
+
+# Start the application with Uvicorn
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/genai/language/embeddings/README.md
+++ b/genai/language/embeddings/README.md
@@ -1,0 +1,4 @@
+## Embeddings API
+
+Generates [GenAI embeddings](https://quantumblack.medium.com/embeddings-the-language-of-llms-and-genai-b74c2bef105a)
+using the [SentenceTransformers framework](https://www.sbert.net/), useful for semantic textual similarity.

--- a/genai/language/embeddings/k8s.yaml
+++ b/genai/language/embeddings/k8s.yaml
@@ -1,0 +1,84 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: embeddings-api
+  labels:
+    name: embeddings-api
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 40%
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      name: embeddings-api
+  template:
+    metadata:
+      labels:
+        name: embeddings-api
+        version: stable
+      annotations:
+        instrumentation.opentelemetry.io/inject-python: "genai-instrumentation"
+    spec:
+      serviceAccountName: k8s-sa-aiplatform
+      restartPolicy: Always
+      containers:
+      - image: embeddings-api
+        name: embeddings-api
+        imagePullPolicy: Always
+        ports:
+        - name: http
+          containerPort: 8080
+          protocol: TCP
+        # readinessProbe:
+        #   httpGet:
+        #     path: /health
+        #     port: http-front
+        #   initialDelaySeconds: 5
+        #   periodSeconds: 5
+        # livenessProbe:
+        #   tcpSocket:
+        #     port: http-front
+        #   initialDelaySeconds: 5
+        #   periodSeconds: 5
+        env:
+        - name: ENV
+          value: dev
+        # resources:
+        #   requests:
+        #     cpu: 100m
+        #     memory: 512Gi
+        #   limits:
+        #     memory: 1Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: embeddings-api
+  name: embeddings-api
+spec:
+  ports:
+  - name: http
+    port: 80
+    targetPort: 8080
+    protocol: TCP
+  selector:
+    name: embeddings-api
+  sessionAffinity: None
+  type: ClusterIP
+# ---
+# apiVersion: autoscaling/v1
+# kind: HorizontalPodAutoscaler
+# metadata:
+#   name: embeddings-api
+# spec:
+#   scaleTargetRef:
+#     apiVersion: apps/v1
+#     kind: Deployment
+#     name: embeddings-api
+#   minReplicas: 5
+#   maxReplicas: 30
+#   targetCPUUtilizationPercentage: 50

--- a/genai/language/embeddings/skaffold.yaml
+++ b/genai/language/embeddings/skaffold.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC All Rights Reserved.
+# Copyright 2023 Google LLC All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,11 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-uvicorn==0.23.2
-fastapi==0.104.0
-pydantic==2.4.2
-google-cloud-aiplatform==1.40.0
-google-cloud-spanner==3.42.0
-requests==2.31.0
-openai==1.12.0
-jinja2==3.1.3
+apiVersion: skaffold/v3
+kind: Config
+metadata:
+  name: embeddings-api-cfg
+build:
+  googleCloudBuild: {}
+  tagPolicy:
+    sha256: {}
+  artifacts:
+  - image: embeddings-api
+    context: .
+manifests:
+  rawYaml:
+  - ./k8s.yaml
+deploy:
+  kubectl:
+    flags:
+      global:
+      - --namespace=genai
+requires:
+- configs: ["common"]
+  path: ../../common/skaffold.yaml

--- a/genai/language/embeddings/src/example_api_call.py
+++ b/genai/language/embeddings/src/example_api_call.py
@@ -1,0 +1,60 @@
+# Copyright 2024 Google LLC All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import logging
+import requests
+import argparse
+
+from json import loads
+
+logging.basicConfig(level=logging.INFO, stream=sys.stdout)
+
+def dot(v1, v2):
+   return sum(i[0] * i[1] for i in zip(v1, v2))
+
+def test_endpoint(endpoint, prompts, model):
+    json = {'prompts': prompts}
+    if model:
+        json['model'] = model
+
+    req = requests.post(
+        url = endpoint,
+        headers = {"Content-Type": "application/json"},
+        json = json,
+    )
+
+    logging.info(f'Status Code: {req.status_code}')
+    logging.info(f'Response:    {req.text}')
+
+    if req.status_code != 200 or len(prompts) <= 1:
+        logging.info(f'(not showing similarity - error or too few prompts)')
+        return
+
+    embeddings = loads(req.text)
+    embeddings = list(zip(embeddings['prompts'], embeddings['embeddings']))
+    for i in range(len(embeddings)):
+        for j in range(i+1, len(embeddings)):
+            d = dot(embeddings[i][1], embeddings[j][1])
+            logging.info(f'Dot product similarity between "{embeddings[i][0]}" and "{embeddings[j][0]}": {d}')
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="")
+    parser.add_argument("--endpoint", required=True, help="LLM Endpoint with route, such as http://localhost:7777/my_test_route")
+    parser.add_argument("--prompt", required=True, help="LLM Prompt (repeated - embeddings in order of args)", nargs='+', default=[])
+    parser.add_argument("--model", default="sentence-transformers/multi-qa-MiniLM-L6-cos-v1", help="Sentence transformer model to use")
+    args = parser.parse_args()
+
+    test_endpoint(endpoint=args.endpoint, prompts=args.prompt, model=args.model)
+

--- a/genai/language/embeddings/src/main.py
+++ b/genai/language/embeddings/src/main.py
@@ -1,0 +1,84 @@
+# Copyright 2024 Google LLC All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+from sentence_transformers import SentenceTransformer
+from typing import List
+import sys
+import traceback
+import logging
+
+WARMUP_SENTENCE='a warm model is a fast model'
+
+logging.basicConfig(
+    level=logging.DEBUG,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+    stream=sys.stdout,
+)
+
+app = FastAPI(
+    redoc_url=None,
+    title="API for GenAI Embeddings",
+    description="Generates Embedding vectors for sentences given the model specified.",
+    version="0.0.1",
+)
+
+class Payload_Embeddings(BaseModel):
+    model: str
+    prompts: List[str]
+
+
+model_cache = {}
+
+
+def get_model(model_name) -> SentenceTransformer:
+    if model_name not in model_cache:
+        try:
+            model_cache[model_name] = SentenceTransformer(model_name)
+        except Exception as e:
+            raise HTTPException(status_code=404, detail=f'Model named "{model_name}" not found (browse https://huggingface.co/sentence-transformers for valid models)')
+    return model_cache[model_name]
+
+
+def get_embeddings(model_name: str, prompts: List[str]):
+    return get_model(model_name).encode(prompts, show_progress_bar=False, convert_to_tensor=True, normalize_embeddings=True).tolist()
+
+
+# Routes
+
+
+@app.get("/genai_health", include_in_schema=False)
+async def health_check():
+    return {'status': 'ok'}
+
+@app.post("/")
+def embeddings(payload: Payload_Embeddings):
+    try:
+        return {
+            'model': payload.model,
+            'prompts': payload.prompts,
+            'embeddings': get_embeddings(payload.model, payload.prompts),
+        }
+    except HTTPException as e:
+        raise
+    except Exception as e:
+        traceback.print_exception(e)
+        raise HTTPException(status_code=500, detail="Internal error")
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=7777)
+

--- a/genai/language/embeddings/src/requirements.txt
+++ b/genai/language/embeddings/src/requirements.txt
@@ -15,8 +15,5 @@
 uvicorn==0.23.2
 fastapi==0.104.0
 pydantic==2.4.2
-google-cloud-aiplatform==1.40.0
-google-cloud-spanner==3.42.0
 requests==2.31.0
-openai==1.12.0
-jinja2==3.1.3
+sentence_transformers==2.3.1

--- a/genai/language/huggingface_tgi/README.md
+++ b/genai/language/huggingface_tgi/README.md
@@ -1,0 +1,27 @@
+## HuggingFace Text Generation Inference
+
+Simple deployment of the [HuggingFace Text Generation Inference](https://huggingface.co/docs/text-generation-inference/en/index) 
+(TGI) server running on GPUs.
+
+You will need a GPU node pool to run this, for example:
+```
+gcloud container node-pools create gpu-l4x2-ssd --cluster genai-quickstart   --accelerator type=nvidia-l4,count=2,gpu-driver-version=latest   --machine-type g2-standard-24   --enable-image-streaming  --num-nodes=1 --min-nodes=1 --max-nodes=2  --zone us-west1-b --ephemeral-storage-local-ssd=count=2
+```
+
+To deploy:
+```
+# Set CUR_DIR to the top level directory of the git repo
+export CUR_DIR=$(pwd)
+
+cd genai/language/huggingface_tgi
+skaffold run
+```
+
+To test:
+```
+kubectl port-forward -n genai svc/huggingface-tgi-api 8080:8080
+
+# in appropriate virtualenv
+cd $CURDIR
+python3 genai/language/huggingface_tgi/example_api_call.py --endpoint http://localhost:8080/v1
+```

--- a/genai/language/huggingface_tgi/example_api_call.py
+++ b/genai/language/huggingface_tgi/example_api_call.py
@@ -1,0 +1,48 @@
+# Copyright 2024 Google LLC All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import logging
+import openai
+import sys
+
+logging.basicConfig(level=logging.INFO, stream=sys.stdout)
+
+def chat_endpoint(endpoint, system):
+    client = openai.OpenAI(
+        base_url=endpoint,
+        api_key="NOT NEEDED"
+    )
+
+    messages=[{"role": "system", "content": system}] if system else []
+    while True:
+        try:
+            message = input('>>> ')
+        except EOFError:
+            return
+
+        messages.append({"role": "user", "content": message.strip()})
+
+        completion = client.chat.completions.create(model="tgi", messages=messages)
+        resp = completion.choices[0].message.content
+        messages.append({"role": "assistant", "content": resp})
+        print('<<<', resp)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="")
+    parser.add_argument("--endpoint", required=True, help="LLM Endpoint with route, such as http://localhost:7777/my_test_route")
+    parser.add_argument("--system", help="System prompt, if API supports it")
+    args = parser.parse_args()
+    chat_endpoint(args.endpoint, args.system)
+

--- a/genai/language/huggingface_tgi/k8s.yaml
+++ b/genai/language/huggingface_tgi/k8s.yaml
@@ -1,0 +1,88 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: huggingface-tgi-api
+  labels:
+    name: huggingface-tgi-api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: huggingface-tgi-api
+  template:
+    metadata:
+      labels:
+        name: huggingface-tgi-api
+    spec:
+      serviceAccountName: k8s-sa-aiplatform
+      containers:
+        - name: huggingface-tgi-api
+          ports:
+            - containerPort: 80
+          image: ghcr.io/huggingface/text-generation-inference:1.4.2
+          # Use this image for Gemma support:
+          # image: us-docker.pkg.dev/vertex-ai/vertex-vision-model-garden-dockers/pytorch-hf-tgi-serve:20240220_0936_RC01
+          args:
+            # Choose models with multiturn chat support
+            # Look for `chat_template`, e.g.: https://huggingface.co/HuggingFaceH4/zephyr-7b-beta/blob/main/tokenizer_config.json#L34
+            # Alternatives if you don't have an API Key:
+            # - --model-id=mistralai/Mistral-7B-Instruct-v0.2
+            # - --model-id=HuggingFaceH4/zephyr-7b-beta
+            #
+            # To run Gemma:
+            # - --model-id=google/gemma-7b-it
+            # (but you'll need the updated image above)
+            #
+            # Another alternative, but you'll need a bunch of ephemeral storage:
+            - --model-id=mistralai/Mixtral-8x7B-Instruct-v0.1
+            # To run on L4s we have to quantize
+            - --quantize=bitsandbytes-nf4
+            # - --quantize=gptq
+            #
+            # --num-shard should match nvidia.com/gpu: limits
+            - --num-shard=2
+          # To use Gemma, you need to uncomment and fill this in. (Preferably, use a secret or a secret manager instead.)
+          # env:
+          # - name: HUGGING_FACE_HUB_TOKEN
+          #   value: <your API key>
+          resources:
+            requests:
+              cpu: "2"
+              memory: "25Gi"
+              ephemeral-storage: "200Gi"
+              nvidia.com/gpu: 2
+            limits:
+              cpu: "20"
+              memory: "80Gi"
+              ephemeral-storage: "600Gi"
+              nvidia.com/gpu: 2
+          volumeMounts:
+            - mountPath: /dev/shm
+              name: shm
+            - mountPath: /data
+              name: data 
+      volumes:
+        # # c.f. https://github.com/huggingface/text-generation-inference#a-note-on-shared-memory-shm
+        - name: shm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 1Gi
+        - name: data
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: huggingface-tgi-api
+  name: huggingface-tgi-api
+spec:
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 80
+    protocol: TCP
+  selector:
+    name: huggingface-tgi-api
+  sessionAffinity: None
+  type: ClusterIP

--- a/genai/language/huggingface_tgi/skaffold.yaml
+++ b/genai/language/huggingface_tgi/skaffold.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC All Rights Reserved.
+# Copyright 2023 Google LLC All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,11 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-uvicorn==0.23.2
-fastapi==0.104.0
-pydantic==2.4.2
-google-cloud-aiplatform==1.40.0
-google-cloud-spanner==3.42.0
-requests==2.31.0
-openai==1.12.0
-jinja2==3.1.3
+apiVersion: skaffold/v3
+kind: Config
+metadata:
+  name: huggingface-tgi-endpt-cfg
+manifests:
+  rawYaml:
+  - ./k8s.yaml
+deploy:
+  kubectl:
+    flags:
+      global:
+      - --namespace=genai
+requires:
+- configs: ["common"]
+  path: ../../common/skaffold.yaml


### PR DESCRIPTION
* Adds Text Generation Inference endpoint and Embeddings endpoint
  * Adds simple deployment of HuggingFace TGI, plus service
  * Adds a service wrapping the SentenceTransformers framework for embeddings

* Adds a "GKEGenAI" option to the npc_chat_api config that calls TGI directly. The config allows for testing against either TGI or the Gemma-TGI image, plus different options depending on whether the model fully supports chat templates or not.

Along the way:

* Added a `/debug on` command to the NPC example program

* Now requiring `from_id` and `to_id` in Chat API, pushed the default up to the example driver

* Ported the "chat" example_api_call.py over to huggingface TGI to kick the tires on it more easily, too.

* Moved to mistralai/Mixtral-8x7B-Instruct-v0.1 as a large but quality model. My current configuration of this is rather slow, though, so I'm working to figure that out eventually here.

Note if picking this up: This is the node pool create I did to run Mixtral-8x7B (but we may want to try A100s).

```
gcloud container node-pools create gpu-l4x2-ssd --cluster genai-quickstart   --accelerator type=nvidia-l4,count=2,gpu-driver-version=latest   --machine-type g2-standard-24   --enable-image-streaming  --num-nodes=1 --min-nodes=1 --max-nodes=2  --zone us-west1-b --ephemeral-storage-local-ssd=count=2
```

(It's also mentioned in the README)