### PR TITLE
Changes the GKE Cluster from Zonal to Regional Autopilot Cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ If you’re using this project, please ★Star this repository to show your inte
 
 - [Terraform](https://www.terraform.io/downloads.html)
 - [gcloud](https://cloud.google.com/sdk/docs/install)
-- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
-- [skaffold](https://skaffold.dev/docs/)
+- [kubectl](https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-access-for-kubectl#install_kubectl)
+- [Skaffold](https://skaffold.dev/docs/)
 - [Helm](https://helm.sh/docs/intro/install/)
 
 ## Getting started

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ export PROJECT_ID=$(gcloud config list --format 'value(core.project)' 2>/dev/nul
 Set default location for Google Cloud
 
 ```
-export LOCATION=us-west1
+export LOCATION=us-central1
 ```
 
 To better follow along with this quickstart guide, set `CUR_DIR` env variable
@@ -113,7 +113,7 @@ The deployment of cloud resources can take between 5 - 10 minutes. For a detaile
 After cloud resources have successfully been deployed with Terraform. Get newly created GKE cluster credentials.
 
 ```
-gcloud container clusters get-credentials genai-quickstart --region us-west1 --project $PROJECT_ID
+gcloud container clusters get-credentials genai-quickstart --region us-central1 --project $PROJECT_ID
 ```
 
 ### 7) Deploy GenAI workloads on GKE

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ If you’re using this project, please ★Star this repository to show your inte
 | [examples](./examples)        | Individual quickstarts that can be tested and deployed based on your use case |
 | [src](./src)                  | Core source code that is used as part of our quickstarts |
 
-## Architecture 
+## Architecture
 
 ![Architecture](images/genai-api-arch.png)
 
@@ -26,6 +26,7 @@ If you’re using this project, please ★Star this repository to show your inte
 - [gcloud](https://cloud.google.com/sdk/docs/install)
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
 - [skaffold](https://skaffold.dev/docs/)
+- [Helm](https://helm.sh/docs/intro/install/)
 
 ## Getting started
 
@@ -112,7 +113,7 @@ The deployment of cloud resources can take between 5 - 10 minutes. For a detaile
 After cloud resources have successfully been deployed with Terraform. Get newly created GKE cluster credentials.
 
 ```
-gcloud container clusters get-credentials genai-quickstart --zone us-west1-b --project $PROJECT_ID
+gcloud container clusters get-credentials genai-quickstart --region us-west1 --project $PROJECT_ID
 ```
 
 ### 7) Deploy GenAI workloads on GKE

--- a/genai/api/npc_chat_api/README.md
+++ b/genai/api/npc_chat_api/README.md
@@ -3,7 +3,7 @@
 > [!NOTE]
 > Work in progress!
 
-The NPC Chat API demonstrates using [RAG](https://www.promptingguide.ai/techniques/rag) to create a 
+The NPC Chat API demonstrates using [RAG](https://www.promptingguide.ai/techniques/rag) to create a
 smart NPC for your game, enriched by world knowledge, NPC-specific knowledge, and secondhand
 knowledge from chat.
 
@@ -18,7 +18,7 @@ To try it out:
 export PROJECT_ID=$(gcloud config list --format 'value(core.project)' 2>/dev/null)
 
 # Set location of Artifact Registry previously created for Skaffold builds by Terraform
-export LOCATION=us-west1
+export LOCATION=us-central1
 
 # Set CUR_DIR to the top level directory of the git repo
 export CUR_DIR=$(pwd)

--- a/genai/common/opentelemetry/otel-collector.yaml
+++ b/genai/common/opentelemetry/otel-collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: otel
 spec:
   mode: deployment
-  hostNetwork: true
+  hostNetwork: false
   image: otel/opentelemetry-collector-contrib:latest
   config: |
     receivers:

--- a/genai/image/stable_diffusion/k8s.yaml
+++ b/genai/image/stable_diffusion/k8s.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       restartPolicy: Always
       nodeSelector:
-        cloud.google.com/gke-accelerator: "nvidia-tesla-t4"
+        cloud.google.com/gke-accelerator: "nvidia-l4"
       containers:
       - image: stable-diffusion-endpt
         name: stable-diffusion-endpt

--- a/genai/language/huggingface_tgi/README.md
+++ b/genai/language/huggingface_tgi/README.md
@@ -1,12 +1,7 @@
 ## HuggingFace Text Generation Inference
 
-Simple deployment of the [HuggingFace Text Generation Inference](https://huggingface.co/docs/text-generation-inference/en/index) 
+Simple deployment of the [HuggingFace Text Generation Inference](https://huggingface.co/docs/text-generation-inference/en/index)
 (TGI) server running on GPUs.
-
-You will need a GPU node pool to run this, for example:
-```
-gcloud container node-pools create gpu-l4x2-ssd --cluster genai-quickstart   --accelerator type=nvidia-l4,count=2,gpu-driver-version=latest   --machine-type g2-standard-24   --enable-image-streaming  --num-nodes=1 --min-nodes=1 --max-nodes=2  --zone us-west1-b --ephemeral-storage-local-ssd=count=2
-```
 
 To deploy:
 ```

--- a/genai/language/huggingface_tgi/k8s.yaml
+++ b/genai/language/huggingface_tgi/k8s.yaml
@@ -15,6 +15,8 @@ spec:
         name: huggingface-tgi-api
     spec:
       serviceAccountName: k8s-sa-aiplatform
+      nodeSelector:
+        cloud.google.com/gke-accelerator: "nvidia-l4"
       containers:
         - name: huggingface-tgi-api
           ports:
@@ -60,7 +62,7 @@ spec:
             - mountPath: /dev/shm
               name: shm
             - mountPath: /data
-              name: data 
+              name: data
       volumes:
         # # c.f. https://github.com/huggingface/text-generation-inference#a-note-on-shared-memory-shm
         - name: shm

--- a/genai/skaffold.yaml
+++ b/genai/skaffold.yaml
@@ -12,34 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Cert Manager config
-apiVersion: skaffold/v3
-kind: Config
-metadata:
-  name: cert-manager-cfg
-manifests:
-  rawYaml:
-  - https://github.com/cert-manager/cert-manager/releases/download/v1.12.0/cert-manager.yaml
-deploy:
-  kubectl: {}
----
 #OpenTelemetry Installation
 apiVersion: skaffold/v3
 kind: Config
 metadata:
   name: open-telemetry-cfg
-manifests:
-  rawYaml:
-  - https://github.com/open-telemetry/opentelemetry-operator/releases/latest/download/opentelemetry-operator.yaml
 deploy:
-  kubectl:
-    hooks:
-      before:
-        - host:
-            command: ["sh", "-c", "echo Waiting for cert-manager stabilization; sleep 90"]
-      after:
-        - host:
-            command: ["sh", "-c", "sleep 10"]
+  helm:
+    releases:
+      - name: otel-operator
+        createNamespace: true
+        namespace: "opentelemetry-operator-system"
+        wait: true
+        remoteChart: opentelemetry-operator
+        repo: https://open-telemetry.github.io/opentelemetry-helm-charts
+        setValues:
+          admissionWebhooks.certManager.enabled: false # Disable certManager
+          admissionWebhooks.certManager.autoGenerateCert.enabled: true # Helm will create a self-signed cert and secret
+          image.pullPolicy: "IfNotPresent"
 ---
 apiVersion: skaffold/v4beta1
 kind: Config

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -41,7 +41,7 @@ Legend: <code>+</code> additive, <code>•</code> conditional.
 |---|---|---|---|
 | [bootstrap.tf](./bootstrap.tf) | Bootstrapping prerequisites for project. |  |  |
 | [cicd.tf](./gke.tf) | Recources created to CI/CD pipeline. |  | `google_artifact_registry_repository` |
-| [gke.tf](./gke.tf) | GKE cluster with game server and GPU nodepools for GenAI. | [`gke`](https://registry.terraform.io/modules/terraform-google-modules/kubernetes-engine/google/latest/submodules/beta-private-cluster) |  |
+| [gke.tf](./gke.tf) | GKE Autopilot cluster for running GenAI workloads. | [`gke`](https://registry.terraform.io/modules/terraform-google-modules/kubernetes-engine/google/latest/submodules/beta-autopilot-public-cluster) |  |
 | [iam.tf](./gke.tf) | IAM resources for project needed by Cloud resources. | [`member_roles_gke`, `member_roles_aiplatform`, `member_roles_telemetry`, `member_roles_cloudbuild`](https://registry.terraform.io/modules/terraform-google-modules/iam/google/latest/submodules/member_iam) | `google_service_account.sa_gke_cluster`, `google_service_account.sa_gke_aiplatform`, `google_service_account.sa_gke_telemetry` · `google_service_account_iam_binding.sa_gke_cluster_wi_binding`, `google_service_account_iam_binding.sa_gke_aiplatform_wi_binding`, `google_service_account_iam_binding.sa_gke_telemetry_wi_binding` |
 | [net.tf](./net.tf) | VPC network and firewall rules. | [`vpc`](https://registry.terraform.io/modules/terraform-google-modules/network/google/latest) |  |
 

--- a/terraform/cicd.tf
+++ b/terraform/cicd.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 resource "google_artifact_registry_repository" "repo" {
-  location      = "us-west1"
+  location      = "us-central1"
   repository_id = "repo-genai-quickstart"
   description   = "GenAI Quickstart Artifact Registry."
   format        = "DOCKER"

--- a/terraform/gke.tf
+++ b/terraform/gke.tf
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC All Rights Reserved.
+# Copyright 2024 Google LLC All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,39 +12,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# google_client_config and kubernetes provider must be explicitly specified like the following.
+data "google_client_config" "default" {}
+
 provider "kubernetes" {
   host                   = "https://${module.gke.endpoint}"
   token                  = data.google_client_config.default.access_token
   cluster_ca_certificate = base64decode(module.gke.ca_certificate)
 }
 
-data "google_client_config" "default" {}
-
 module "gke" {
-  source  = "terraform-google-modules/kubernetes-engine/google//modules/beta-public-cluster"
-  version = "29.0.0"
+  source                     = "terraform-google-modules/kubernetes-engine/google//modules/beta-autopilot-public-cluster"
+  version                    = "29.0.0"
 
   project_id                 = var.project_id
   name                       = "genai-quickstart"
-  regional                   = false
   region                     = "us-west1"
-  zones                      = ["us-west1-b"]
+  zones                      = ["us-west1-a", "us-west1-b", "us-west1-c"]
   network                    = module.vpc.network_name
   subnetwork                 = "sn-usw1"
   ip_range_pods              = "sn-usw1-pods1"
   ip_range_services          = "sn-usw1-svcs1"
-  remove_default_node_pool   = true
-  http_load_balancing        = true
-  default_max_pods_per_node  = 32
   horizontal_pod_autoscaling = true
-  filestore_csi_driver       = false
-  release_channel            = "REGULAR"
-  identity_namespace         = "enabled"
-  create_service_account     = false
+  release_channel            = "RAPID"
   service_account            = google_service_account.sa_gke_cluster.email
-  enable_shielded_nodes      = true
-  # enable_gcfs	               = true # Cluster wide image streaming
-  deletion_protection        = false
 
   # Need to allow 48 hour window in rolling 32 days For `maintenance_start_time`
   # & `end_time` only the specified time of the day is used, the specified date
@@ -52,98 +43,5 @@ module "gke" {
   maintenance_recurrence = "FREQ=WEEKLY;BYDAY=SU"
   maintenance_start_time = "2023-01-02T07:00:00Z"
   maintenance_end_time   = "2023-01-02T19:00:00Z"
-
-  cluster_autoscaling = {
-    auto_repair         = true
-    auto_upgrade        = true
-    autoscaling_profile = "OPTIMIZE_UTILIZATION"
-    # NAP configurations (disabled by default)
-    enabled       = false
-    min_cpu_cores = 0
-    max_cpu_cores = 0
-    min_memory_gb = 0
-    max_memory_gb = 0
-    gpu_resources = []
-  }
-
-  node_pools = [
-    {
-      # CPU based nodepool
-      name                        = "nodepool-cpu"
-      default-node-pool           = true
-      machine_type                = "e2-standard-2"
-      image_type                  = "COS_CONTAINERD"
-      disk_size_gb                = 100
-      disk_type                   = "pd-standard"
-      autoscaling                 = true
-      enable_secure_boot          = true
-      enable_integrity_monitoring = true
-      enable_gcfs                 = true
-      initial_node_count          = 1
-      min_count                   = 1
-      max_count                   = 5
-      location_policy             = "ANY"
-    },
-    {
-      # GPU based nodepool
-      name                        = "nodepool-gpu"
-      machine_type                = "n1-standard-2"
-      accelerator_type            = "nvidia-tesla-t4"
-      accelerator_count           = 1
-      gpu_driver_version          = "DEFAULT" #can be set to "LATEST" or "DEFAULT"
-      image_type                  = "COS_CONTAINERD"
-      disk_size_gb                = 100
-      disk_type                   = "pd-standard"
-      autoscaling                 = true
-      enable_secure_boot          = true
-      enable_integrity_monitoring = true
-      enable_gcfs                 = true
-      initial_node_count          = 0
-      min_count                   = 0
-      max_count                   = 2
-      location_policy             = "ANY"
-    }
-  ]
-
-  node_pools_oauth_scopes = {
-    all = [
-      "https://www.googleapis.com/auth/logging.write",
-      "https://www.googleapis.com/auth/monitoring",
-      "https://www.googleapis.com/auth/trace.append",
-      "https://www.googleapis.com/auth/devstorage.read_only",
-      "https://www.googleapis.com/auth/service.management.readonly",
-      "https://www.googleapis.com/auth/servicecontrol",
-    ]
-  }
-
-  node_pools_tags = {
-    all = []
-
-    "nodepool-cpu" = [
-      "default",
-      "cpu",
-      "game-server",
-    ]
-
-    "nodepool-gpu" = [
-      "gpu",
-    ]
-  }
-
-  node_pools_taints = {
-    all = []
-
-    "nodepool-gpu" = [
-      {
-        key    = "nvidia.com/gpu"
-        value  = true
-        effect = "NO_SCHEDULE"
-      },
-    ]
-  }
-
-  depends_on = [
-    google_service_account.sa_gke_cluster,
-    module.vpc
-  ]
 }
+

--- a/terraform/gke.tf
+++ b/terraform/gke.tf
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC All Rights Reserved.
+# Copyright 2023 Google LLC All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -28,13 +28,12 @@ module "gke" {
   project_id                 = var.project_id
   name                       = "genai-quickstart"
   region                     = "us-central1"
-  zones                      = ["us-central1-a", "us-central1-b", "us-central1-c"]
   network                    = module.vpc.network_name
   subnetwork                 = "sn-usc1"
   ip_range_pods              = "sn-usc1-pods1"
   ip_range_services          = "sn-usc1-svcs1"
   horizontal_pod_autoscaling = true
-  release_channel            = "RAPID"
+  release_channel            = "RAPID" # RAPID was chosen for L4 support.
   service_account            = google_service_account.sa_gke_cluster.email
 
   # Need to allow 48 hour window in rolling 32 days For `maintenance_start_time`
@@ -43,5 +42,10 @@ module "gke" {
   maintenance_recurrence = "FREQ=WEEKLY;BYDAY=SU"
   maintenance_start_time = "2023-01-02T07:00:00Z"
   maintenance_end_time   = "2023-01-02T19:00:00Z"
+
+  depends_on = [
+    google_service_account.sa_gke_cluster,
+    module.vpc
+  ]
 }
 

--- a/terraform/gke.tf
+++ b/terraform/gke.tf
@@ -27,12 +27,12 @@ module "gke" {
 
   project_id                 = var.project_id
   name                       = "genai-quickstart"
-  region                     = "us-west1"
-  zones                      = ["us-west1-a", "us-west1-b", "us-west1-c"]
+  region                     = "us-central1"
+  zones                      = ["us-central1-a", "us-central1-b", "us-central1-c"]
   network                    = module.vpc.network_name
-  subnetwork                 = "sn-usw1"
-  ip_range_pods              = "sn-usw1-pods1"
-  ip_range_services          = "sn-usw1-svcs1"
+  subnetwork                 = "sn-usc1"
+  ip_range_pods              = "sn-usc1-pods1"
+  ip_range_services          = "sn-usc1-svcs1"
   horizontal_pod_autoscaling = true
   release_channel            = "RAPID"
   service_account            = google_service_account.sa_gke_cluster.email

--- a/terraform/net.tf
+++ b/terraform/net.tf
@@ -22,23 +22,23 @@ module "vpc" {
 
   subnets = [
     {
-      subnet_name           = "sn-usw1"
+      subnet_name           = "sn-usc1"
       subnet_ip             = "10.11.16.0/20"
-      subnet_region         = "us-west1"
+      subnet_region         = "us-central1"
       subnet_private_access = "true"
       subnet_flow_logs      = "false"
-      description           = "Subnet for US West1"
+      description           = "Subnet for US central1"
     }
   ]
 
   secondary_ranges = {
-    "sn-usw1" = [
+    "sn-usc1" = [
       {
-        range_name    = "sn-usw1-pods1"
+        range_name    = "sn-usc1-pods1"
         ip_cidr_range = "10.11.0.0/20"
       },
       {
-        range_name    = "sn-usw1-svcs1"
+        range_name    = "sn-usc1-svcs1"
         ip_cidr_range = "10.111.0.0/25"
       },
     ]

--- a/terraform/spanner.tf
+++ b/terraform/spanner.tf
@@ -1,7 +1,7 @@
 resource "google_spanner_instance" "npc-chat" {
   name             = "npc-chat"
   display_name     = "Data behind npc-chat-api"
-  config           = "regional-us-west1"
+  config           = "regional-us-central1"
   autoscaling_config {
     autoscaling_limits {
       max_processing_units            = 10000
@@ -45,7 +45,7 @@ resource "google_spanner_database" "npc-chat" {
   EOT
   , <<-EOT
     CREATE INDEX EntityHistoryDynamicByEntityAndTarget
-    ON EntityHistoryDynamic(EntityId, TargetEntityId, EventTime DESC, MessageId DESC) 
+    ON EntityHistoryDynamic(EntityId, TargetEntityId, EventTime DESC, MessageId DESC)
     STORING (EntityName, TargetEntityName, EventDescription, EventDescriptionEmbedding)
   EOT
   , <<-EOT


### PR DESCRIPTION
- Removes the cert-manager installation as this needed to be parameterized in order to work with the Autopilot cluster.
- Adds Helm as a dependency which is needed to be able to install opentelemetry without cert-manager.
- Helm creates a self-signed certificate for opentelemetry.
- Updates the stable diffusion to use the same type of L4 GPU that the NPC API uses.
- Updates release channel to "RAPID" as the L4 GPUs only work in Autopilot 1.28+, and RAPID is the current channel where the default version is 1.28+