### PR TITLE
Fix HF TGI deployment for Autopilot

### DIFF
--- a/genai/language/huggingface_tgi/k8s.yaml
+++ b/genai/language/huggingface_tgi/k8s.yaml
@@ -17,6 +17,8 @@ spec:
       serviceAccountName: k8s-sa-aiplatform
       nodeSelector:
         cloud.google.com/gke-accelerator: "nvidia-l4"
+        cloud.google.com/gke-ephemeral-storage-local-ssd: "true"
+        cloud.google.com/compute-class: "Accelerator"
       containers:
         - name: huggingface-tgi-api
           ports:

--- a/terraform/gke.tf
+++ b/terraform/gke.tf
@@ -34,6 +34,7 @@ module "gke" {
   ip_range_services          = "sn-usc1-svcs1"
   horizontal_pod_autoscaling = true
   release_channel            = "RAPID" # RAPID was chosen for L4 support.
+  kubernetes_version         = "1.29"  # We need the tip of 1.29 (not just default)
   service_account            = google_service_account.sa_gke_cluster.email
 
   # Need to allow 48 hour window in rolling 32 days For `maintenance_start_time`


### PR DESCRIPTION
* Pin to version 1.29 (we need it for local ephemeral SSD on Autopilot)
* Add appropriate node selectors to get local ephemeral SSD

Fixes a minor issue in #29 