### PR TITLE
Add an `api_called` image that you can `kubectl run` to play with APIs

### DIFF
--- a/genai/api/genai_api/src/requirements.txt
+++ b/genai/api/genai_api/src/requirements.txt
@@ -15,5 +15,5 @@
 uvicorn==0.23.2
 fastapi==0.109.1
 pydantic==2.4.2
-google-cloud-aiplatform==1.38.1
+google-cloud-aiplatform==1.40.0
 requests==2.31.0

--- a/genai/api/npc_chat_api/src/main.py
+++ b/genai/api/npc_chat_api/src/main.py
@@ -84,7 +84,9 @@ class Payload_NPC_Chat(BaseModel):
 @app.post("/")
 def npc_chat(payload: Payload_NPC_Chat):
     try:
+        logging.info(f'payload: {payload}')
         resp = npcs[0].reply(payload.from_id, "Jane", payload.message)
+        logging.debug(f'resp: {resp}')
         if not payload.debug:
             # Filter to just the response
             resp = {"response": resp['response']}

--- a/genai/api/npc_chat_api/src/npc/genai.py
+++ b/genai/api/npc_chat_api/src/npc/genai.py
@@ -95,7 +95,6 @@ class GKEGenAI(object):
         assert messages[-1]['role'] == 'assistant' # last message in history should be bot
         messages.append({'role': 'user', 'content': message})
 
-        logging.info(f'_translate_messages={messages}')
         return messages
 
     class ChatCompletions(object):

--- a/genai/api/stable_diffusion_api/src/requirements.txt
+++ b/genai/api/stable_diffusion_api/src/requirements.txt
@@ -15,5 +15,5 @@
 uvicorn==0.23.2
 fastapi==0.109.1
 pydantic==2.4.2
-google-cloud-aiplatform==1.35.0
+google-cloud-aiplatform==1.40.0
 requests==2.31.0

--- a/genai/api/vertex_chat_api/src/requirements.txt
+++ b/genai/api/vertex_chat_api/src/requirements.txt
@@ -15,5 +15,5 @@
 uvicorn==0.23.2
 fastapi==0.109.1
 pydantic==2.4.2
-google-cloud-aiplatform==1.35.0
+google-cloud-aiplatform==1.40.0
 requests==2.31.0

--- a/genai/api/vertex_code_api/src/requirements.txt
+++ b/genai/api/vertex_code_api/src/requirements.txt
@@ -15,5 +15,5 @@
 uvicorn==0.23.2
 fastapi==0.109.1
 pydantic==2.4.2
-google-cloud-aiplatform==1.35.0
+google-cloud-aiplatform==1.40.0
 requests==2.31.0

--- a/genai/api/vertex_gemini_api/src/requirements.txt
+++ b/genai/api/vertex_gemini_api/src/requirements.txt
@@ -15,5 +15,5 @@
 uvicorn==0.23.2
 fastapi==0.109.1
 pydantic==2.4.2
-google-cloud-aiplatform==1.38.1
+google-cloud-aiplatform==1.40.0
 requests==2.31.0

--- a/genai/api/vertex_image_api/src/requirements.txt
+++ b/genai/api/vertex_image_api/src/requirements.txt
@@ -15,5 +15,5 @@
 uvicorn==0.23.2
 fastapi==0.109.1
 pydantic==2.4.2
-google-cloud-aiplatform==1.38.1
+google-cloud-aiplatform==1.40.0
 requests==2.31.0

--- a/genai/api/vertex_text_api/src/requirements.txt
+++ b/genai/api/vertex_text_api/src/requirements.txt
@@ -15,5 +15,5 @@
 uvicorn==0.23.2
 fastapi==0.109.1
 pydantic==2.4.2
-google-cloud-aiplatform==1.35.0
+google-cloud-aiplatform==1.40.0
 requests==2.31.0

--- a/genai/api_caller/Dockerfile
+++ b/genai/api_caller/Dockerfile
@@ -1,0 +1,37 @@
+# Copyright 2024 Google LLC All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Allow statements and log messages to immediately appear in the Knative logs
+ENV PYTHONUNBUFFERED True
+
+# Install production dependencies. (Copy requirements early to cache this layer.)
+COPY api_caller/requirements.txt /etc/pip_requirements.txt
+RUN pip install --no-cache-dir -r /etc/pip_requirements.txt
+
+COPY api/vertex_code_api/src/example_api_call.py vertex_code_api.py
+COPY api/vertex_text_api/src/example_api_call.py vertex_text_api.py
+COPY api/vertex_chat_api/src/example_api_call.py vertex_chat_api.py
+COPY api/genai_api/src/example_api_call.py genai_api.py
+COPY api/stable_diffusion_api/src/example_api_call.py stable_diffusion_api.py
+COPY api/vertex_image_api/src/example_api_call.py vertex_image_api.py
+COPY api/vertex_gemini_api/src/example_api_call.py vertex_gemini_api.py
+COPY api/npc_chat_api/src/example_api_call.py npc_chat_api.py
+COPY language/huggingface_tgi/example_api_call.py huggingface_tgi.py
+COPY language/embeddings/src/example_api_call.py embeddings.py
+
+ENTRYPOINT ["/bin/bash"]

--- a/genai/api_caller/requirements.txt
+++ b/genai/api_caller/requirements.txt
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http:#www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,9 +13,8 @@
 # limitations under the License.
 
 fastapi==0.109.1
-uvicorn==0.23.2
-diffusers==0.20.0
-transformers==4.36.0
-torch==2.0.1
-accelerate==0.20.3
+openai==1.12.0
 pydantic==2.4.2
+pyyaml==6.0.1
+requests==2.31.0
+uvicorn==0.23.2

--- a/genai/api_caller/skaffold.yaml
+++ b/genai/api_caller/skaffold.yaml
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http:#www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,10 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-fastapi==0.109.1
-uvicorn==0.23.2
-diffusers==0.20.0
-transformers==4.36.0
-torch==2.0.1
-accelerate==0.20.3
-pydantic==2.4.2
+apiVersion: skaffold/v3
+kind: Config
+metadata:
+  name: api-caller-build
+build:
+  googleCloudBuild: {}
+  tagPolicy:
+    sha256: {}
+  artifacts:
+  - image: api-caller
+    context: ..
+    docker:
+      dockerfile: api_caller/Dockerfile

--- a/genai/skaffold.yaml
+++ b/genai/skaffold.yaml
@@ -68,3 +68,6 @@ requires:
 
 - configs: ["npc-chat-api-cfg"]
   path: ./api/npc_chat_api/skaffold.yaml
+
+- configs: ["api-caller-build"]
+  path: ./api_caller/skaffold.yaml


### PR DESCRIPTION
Integrates the various examples_api_call.py into a container with requirements already sorted, good for kicking the tires.

Along the way, harmonize the requirements across containers.

Currently this branch incorporates #33 as well.
