### PR TITLE
Adds StartUp and Readiness Probe to HuggingFace TGI

### DIFF
--- a/genai/language/huggingface_tgi/k8s.yaml
+++ b/genai/language/huggingface_tgi/k8s.yaml
@@ -31,6 +31,18 @@ spec:
           ports:
             - containerPort: 80
           image: ghcr.io/huggingface/text-generation-inference:1.4.2
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 80
+            failureThreshold: 240
+            periodSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 80
+            failureThreshold: 12
+            periodSeconds: 5
           # Use this image for Gemma support:
           # image: us-docker.pkg.dev/vertex-ai/vertex-vision-model-garden-dockers/pytorch-hf-tgi-serve:20240220_0936_RC01
           args:
@@ -113,6 +125,18 @@ spec:
           ports:
             - containerPort: 80
           image: ghcr.io/huggingface/text-generation-inference:1.4.2
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 80
+            failureThreshold: 240
+            periodSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 80
+            failureThreshold: 12
+            periodSeconds: 5
           # Use this image for Gemma support:
           # image: us-docker.pkg.dev/vertex-ai/vertex-vision-model-garden-dockers/pytorch-hf-tgi-serve:20240220_0936_RC01
           args:
@@ -195,6 +219,18 @@ spec:
           ports:
             - containerPort: 80
           image: ghcr.io/huggingface/text-generation-inference:1.4.2
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 80
+            failureThreshold: 240
+            periodSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 80
+            failureThreshold: 12
+            periodSeconds: 5
           # Use this image for Gemma support:
           # image: us-docker.pkg.dev/vertex-ai/vertex-vision-model-garden-dockers/pytorch-hf-tgi-serve:20240220_0936_RC01
           args:


### PR DESCRIPTION
Adds probes to prevent the huggingface-tgi-api service endpoint from being added before the pod is ready.

Tested on the huggingface-tgi-mistral-cpu deployment. The service endpoint last change happens a few milliseconds after the last probe failure was seen:

```
me@me:~/GenAI-quickstart/genai/language/huggingface_tgi$ kubectl get events -o custom-columns=FirstSeen:.firstTimestamp,LastSeen:.lastTimestamp,Count:.count,From:.source.component,Type:.type,Reason:.reason,Message:.message                      --field-selector involvedObject.kind=Pod,involvedObject.name=huggingface-tgi-mistral-cpu-7bdbb4f5f6-wqw48 -ngenai
FirstSeen              LastSeen               Count   From                                    Type      Reason                 Message
2024-03-14T18:05:46Z   2024-03-14T18:05:46Z   1       gke.io/optimize-utilization-scheduler   Warning   FailedScheduling       0/7 nodes are available: 7 node(s) didn't match Pod's node affinity/selector. preemption: 0/7 nodes are available: 7 Preemption is not helpful for scheduling.
2024-03-14T18:06:33Z   2024-03-14T18:06:33Z   1       cluster-autoscaler                      Normal    TriggeredScaleUp       pod triggered scale-up: [{https://www.googleapis.com/compute/v1/projects/igooch-gke-dev/zones/us-central1-c/instanceGroups/gk3-genai-quickstart-nap-xtp56wlg-a46f264a-grp 0->1 (max: 1000)}]
2024-03-14T18:07:59Z   2024-03-14T18:07:59Z   1       gke.io/optimize-utilization-scheduler   Normal    Scheduled              Successfully assigned genai/huggingface-tgi-mistral-cpu-7bdbb4f5f6-wqw48 to gk3-genai-quickstart-nap-xtp56wlg-a46f264a-wb2g
2024-03-14T18:08:01Z   2024-03-14T18:08:01Z   1       kubelet                                 Normal    Pulling                Pulling image "ghcr.io/huggingface/text-generation-inference:1.4.2"
2024-03-14T18:08:03Z   2024-03-14T18:08:03Z   1       taint-eviction-controller               Normal    TaintManagerEviction   Cancelling deletion of Pod genai/huggingface-tgi-mistral-cpu-7bdbb4f5f6-wqw48
2024-03-14T18:09:14Z   2024-03-14T18:09:14Z   1       kubelet                                 Normal    Pulled                 Successfully pulled image "ghcr.io/huggingface/text-generation-inference:1.4.2" in 1m13.035s (1m13.035s including waiting)
2024-03-14T18:09:14Z   2024-03-14T18:09:14Z   1       kubelet                                 Normal    Created                Created container huggingface-tgi-api
2024-03-14T18:09:14Z   2024-03-14T18:09:14Z   1       kubelet                                 Normal    Started                Started container huggingface-tgi-api
2024-03-14T18:09:19Z   2024-03-14T18:10:04Z   10      kubelet                                 Warning   Unhealthy              Startup probe failed: Get "http://10.11.1.2:80/health": dial tcp 10.11.1.2:80: connect: connection refused
```

```
me@me:~$ kubectl describe endpoints huggingface-tgi-api -ngenai
Name:         huggingface-tgi-api
Namespace:    genai
Labels:       name=huggingface-tgi-api
              skaffold.dev/run-id=39ace8b5-3e66-4780-b64b-3f0597a3ee4d
Annotations:  endpoints.kubernetes.io/last-change-trigger-time: 2024-03-14T18:10:10Z
Subsets:
  Addresses:          10.11.1.2
  NotReadyAddresses:  <none>
  Ports:
    Name  Port  Protocol
    ----  ----  --------
    http  80    TCP

Events:  <none>
```
