### PR TITLE
Optimize Spanner queries

### DIFF
--- a/terraform/spanner.tf
+++ b/terraform/spanner.tf
@@ -21,12 +21,13 @@ resource "google_spanner_database" "npc-chat" {
   ddl = [<<-EOT
     CREATE TABLE EntityHistoryBase (
         EntityId INT64,
+        IsWorldData bool,
         EventId INT64,
         EntityName STRING(MAX),
         EntityType INT64,
         EventDescription STRING(MAX),
         EventDescriptionEmbedding ARRAY<FLOAT64>,
-    ) PRIMARY KEY(EntityId, EventId)
+    ) PRIMARY KEY(EntityId, IsWorldData, EventId)
   EOT
   , <<-EOT
     CREATE TABLE EntityHistoryDynamic (


### PR DESCRIPTION
Based on internal discussions, this changes the world data schema so that world data is duplicated into each entity. This prevents hot-spotting on world data keyspace, instead allowing a cleaner partition across the entities.

**BREAKING CHANGE:** Changes Spanner schema in backwards incompatible manner.