### PR TITLE
Adds in game-server tags and tcp firewall for connecting to game servers

### DIFF
--- a/genai/helm_values.yaml
+++ b/genai/helm_values.yaml
@@ -1,0 +1,28 @@
+# Copyright 2024 Google LLC All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Helm values for the opentelemetry-operator chart
+
+# The setValues are here instead of in the skaffold.yaml file because as of opentelemetry-operator
+# version 0.50.0 there must be a --set flag for each key-value pair. The current behavior in
+# skaffold `setValues` is to append all key-pair pairs to a single --set flag which results in an
+# `Error: opentelemetry-operator: - (root): Additional property image is not allowed`.
+
+admissionWebhooks:
+  # Disables certManager
+  certManager:
+    enabled: false
+  # Helm will create a self-signed cert and secret
+  autoGenerateCert:
+    enabled: true

--- a/genai/skaffold.yaml
+++ b/genai/skaffold.yaml
@@ -26,10 +26,7 @@ deploy:
         wait: true
         remoteChart: opentelemetry-operator
         repo: https://open-telemetry.github.io/opentelemetry-helm-charts
-        setValues:
-          admissionWebhooks.certManager.enabled: false # Disable certManager
-          admissionWebhooks.certManager.autoGenerateCert.enabled: true # Helm will create a self-signed cert and secret
-          image.pullPolicy: "IfNotPresent"
+        valuesFiles: ["./helm_values.yaml"]
 ---
 apiVersion: skaffold/v4beta1
 kind: Config

--- a/terraform/gke.tf
+++ b/terraform/gke.tf
@@ -29,6 +29,7 @@ module "gke" {
   name                       = "genai-quickstart"
   region                     = "us-central1"
   network                    = module.vpc.network_name
+  network_tags               = ["game-server"]
   subnetwork                 = "sn-usc1"
   ip_range_pods              = "sn-usc1-pods1"
   ip_range_services          = "sn-usc1-svcs1"

--- a/terraform/net.tf
+++ b/terraform/net.tf
@@ -46,14 +46,27 @@ module "vpc" {
 
   ingress_rules = [
     {
-      name          = "fw-game-server"
-      description   = "Allow game server traffic"
+      name          = "gke-fw-game-server-udp"
+      description   = "Allow UDP game server traffic"
       priority      = 1000
       source_ranges = ["0.0.0.0/0"],
       target_tags   = ["game-server"]
       allow = [
         {
           protocol = "udp"
+          ports    = ["7000-8000"]
+        }
+      ]
+    },
+    {
+      name          = "gke-fw-game-server-tcp"
+      description   = "Allow TCP game server traffic"
+      priority      = 1000
+      source_ranges = ["0.0.0.0/0"],
+      target_tags   = ["game-server"]
+      allow = [
+        {
+          protocol = "tcp"
           ports    = ["7000-8000"]
         }
       ]


### PR DESCRIPTION
- Adds the "game-server" tag to all nodes.
    - This is so the firewall rules will be applied to the nodes with the matching tag.
    - Firewall rule is needed so that a game server can connect to a port on the given port range.
- Also updates the skaffold helm install of opentelemetry to work with the new version 0.50.0