### PR TITLE
Fixes stable diffusion endpoint deployment so that it now runs

### DIFF
--- a/genai/api/genai_api/src/requirements.txt
+++ b/genai/api/genai_api/src/requirements.txt
@@ -14,6 +14,6 @@
 
 uvicorn==0.23.2
 fastapi==0.109.1
-pydantic==2.4.2
+pydantic==2.6.4
 google-cloud-aiplatform==1.40.0
 requests==2.31.0

--- a/genai/api/npc_chat_api/src/requirements.txt
+++ b/genai/api/npc_chat_api/src/requirements.txt
@@ -14,7 +14,7 @@
 
 uvicorn==0.23.2
 fastapi==0.109.1
-pydantic==2.4.2
+pydantic==2.6.4
 google-cloud-aiplatform==1.40.0
 google-cloud-spanner==3.42.0
 requests==2.31.0

--- a/genai/api/stable_diffusion_api/src/requirements.txt
+++ b/genai/api/stable_diffusion_api/src/requirements.txt
@@ -14,6 +14,6 @@
 
 uvicorn==0.23.2
 fastapi==0.109.1
-pydantic==2.4.2
+pydantic==2.6.4
 google-cloud-aiplatform==1.40.0
 requests==2.31.0

--- a/genai/api/vertex_chat_api/src/requirements.txt
+++ b/genai/api/vertex_chat_api/src/requirements.txt
@@ -14,6 +14,6 @@
 
 uvicorn==0.23.2
 fastapi==0.109.1
-pydantic==2.4.2
+pydantic==2.6.4
 google-cloud-aiplatform==1.40.0
 requests==2.31.0

--- a/genai/api/vertex_code_api/src/requirements.txt
+++ b/genai/api/vertex_code_api/src/requirements.txt
@@ -14,6 +14,6 @@
 
 uvicorn==0.23.2
 fastapi==0.109.1
-pydantic==2.4.2
+pydantic==2.6.4
 google-cloud-aiplatform==1.40.0
 requests==2.31.0

--- a/genai/api/vertex_gemini_api/src/requirements.txt
+++ b/genai/api/vertex_gemini_api/src/requirements.txt
@@ -14,6 +14,6 @@
 
 uvicorn==0.23.2
 fastapi==0.109.1
-pydantic==2.4.2
+pydantic==2.6.4
 google-cloud-aiplatform==1.40.0
 requests==2.31.0

--- a/genai/api/vertex_image_api/src/requirements.txt
+++ b/genai/api/vertex_image_api/src/requirements.txt
@@ -14,6 +14,6 @@
 
 uvicorn==0.23.2
 fastapi==0.109.1
-pydantic==2.4.2
+pydantic==2.6.4
 google-cloud-aiplatform==1.40.0
 requests==2.31.0

--- a/genai/api/vertex_text_api/src/requirements.txt
+++ b/genai/api/vertex_text_api/src/requirements.txt
@@ -14,6 +14,6 @@
 
 uvicorn==0.23.2
 fastapi==0.109.1
-pydantic==2.4.2
+pydantic==2.6.4
 google-cloud-aiplatform==1.40.0
 requests==2.31.0

--- a/genai/api_caller/requirements.txt
+++ b/genai/api_caller/requirements.txt
@@ -14,7 +14,7 @@
 
 fastapi==0.109.1
 openai==1.12.0
-pydantic==2.4.2
+pydantic==2.6.4
 pyyaml==6.0.1
 requests==2.31.0
 uvicorn==0.23.2

--- a/genai/image/stable_diffusion/k8s.yaml
+++ b/genai/image/stable_diffusion/k8s.yaml
@@ -25,6 +25,7 @@ spec:
       restartPolicy: Always
       nodeSelector:
         cloud.google.com/gke-accelerator: "nvidia-l4"
+        cloud.google.com/compute-class: "Accelerator"
       containers:
       - image: stable-diffusion-endpt
         name: stable-diffusion-endpt

--- a/genai/image/stable_diffusion/src/requirements.txt
+++ b/genai/image/stable_diffusion/src/requirements.txt
@@ -14,8 +14,8 @@
 
 fastapi==0.109.1
 uvicorn==0.23.2
-diffusers==0.20.0
-transformers==4.36.0
-torch==2.0.1
-accelerate==0.20.3
-pydantic==2.4.2
+diffusers==0.27.2
+transformers==4.39.0
+torch==2.2.1
+accelerate==0.28.0
+pydantic==2.6.4

--- a/genai/image/stable_diffusion/src/utils/model_util.py
+++ b/genai/image/stable_diffusion/src/utils/model_util.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json
-import requests
-import base64
 from io import BytesIO
 from diffusers import StableDiffusionPipeline
 import torch
@@ -27,7 +24,7 @@ class Stable_Diffusion:
         # https://huggingface.co/models
         # Example MODEL_TYPE = 'runwayml/stable-diffusion-v1-5'
         self.model_type = model_type
-        
+
         # Load Model
         self.pipe = StableDiffusionPipeline.from_pretrained(self.model_type, torch_dtype=torch.float16)
         self.pipe = self.pipe.to("cuda")
@@ -40,7 +37,7 @@ class Stable_Diffusion:
             # Process and format image
             buffer = BytesIO()
             image.save(buffer, format="PNG")
-            image_bytes = buffer.getvalue()            
+            image_bytes = buffer.getvalue()
 
             return image_bytes
         except Exception as e:

--- a/genai/language/embeddings/src/requirements.txt
+++ b/genai/language/embeddings/src/requirements.txt
@@ -14,6 +14,6 @@
 
 uvicorn==0.23.2
 fastapi==0.109.1
-pydantic==2.4.2
+pydantic==2.6.4
 requests==2.31.0
 sentence_transformers==2.3.1


### PR DESCRIPTION
When upping the stable-diffusion-endpt replicas from 0 to 1, the `skaffold run` would error with

```
loaded_sub_model = load_method(os.path.join(cached_folder, name), **loading_kwargs) ImportError: Using `low_cpu_mem_usage=True` or a `device_map` requires Accelerate: `pip install accelerate`
```

Updating the the `accelerate` requirement to the latest version fixes this issue. I also updated most of the other requirements to latest, leaving the fastapi and uvicorn at the same version as all of the other APIs. 