### PR TITLE
Migrates guess the sketch to skaffold 

### DIFF
--- a/examples/guess-the-sketch/Dockerfile
+++ b/examples/guess-the-sketch/Dockerfile
@@ -1,0 +1,30 @@
+# Copyright 2024 Google LLC All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Base Image
+FROM python:3.11.5
+
+WORKDIR /workspace/frontend
+COPY src/app.py /workspace/frontend
+COPY src/requirements.txt /workspace/frontend
+COPY src/templates/index.html /workspace/frontend/templates/
+
+# Install Dependencies
+RUN pip install -r requirements.txt
+
+# Expose Port
+EXPOSE 5000
+
+# Start the Application
+CMD ["python", "app.py"]

--- a/examples/guess-the-sketch/README.md
+++ b/examples/guess-the-sketch/README.md
@@ -10,29 +10,14 @@ The gameplay is:
 1. The players will be shown the original prompt and told how close their
    caption was.
 
-
-### To build the demo
-
-```
-# These steps will already be done if you followed the top-level readme
-export PROJECT_ID=$(gcloud config list --format 'value(core.project)' 2>/dev/null)
-export LOCATION=us-central1
-export SKAFFOLD_DEFAULT_REPO=$LOCATION-docker.pkg.dev/$PROJECT_ID/repo-genai-quickstart
-
-cd $CUR_DIR/examples/guess-the-sketch/src
-
-docker build -f Dockerfile --tag=$SKAFFOLD_DEFAULT_REPO/guess-the-sketch:0.1 .
-docker push $SKAFFOLD_DEFAULT_REPO/guess-the-sketch:0.1
-```
-
 ### To run the demo
 
+Follow the top-level README. At least the `http://genai-api.genai.svc/genai/text` and
+`http://genai-api.genai.svc/genai/image` endpoints need to be running.
+
 ```
-cd $CUR_DIR/examples/guess-the-sketch
-
-sed "s:your-image-repo:$SKAFFOLD_DEFAULT_REPO:g" < k8s.yaml > k8s.yaml.new ; mv k8s.yaml.new k8s.yaml
-
-kubectl apply -f k8s.yaml
+cd ~/GenAI-quickstart/examples/guess-the-sketch
+skaffold run --build-concurrency=0
 ```
 
 Once the pod is running, you can connect to the game by running:
@@ -41,5 +26,5 @@ Once the pod is running, you can connect to the game by running:
 kubectl port-forward svc/guess-the-sketch-app 5000:5000
 ```
 
-and opening two pages in your webbrowser at http://localhost:5000/
+and opening two pages in your web browser at http://localhost:5000/
 

--- a/examples/guess-the-sketch/k8s.yaml
+++ b/examples/guess-the-sketch/k8s.yaml
@@ -39,8 +39,8 @@ spec:
         app: guess-the-sketch-app
     spec:
       containers:
-        - name: guess-the-sketch
-          image: your-image-repo/guess-the-sketch:0.1
+        - name: guess-the-sketch-app
+          image: guess-the-sketch-app
           imagePullPolicy: Always
           ports:
             - containerPort: 5000

--- a/examples/guess-the-sketch/skaffold.yaml
+++ b/examples/guess-the-sketch/skaffold.yaml
@@ -1,0 +1,31 @@
+# Copyright 2024 Google LLC All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: skaffold/v3
+kind: Config
+metadata:
+  name: guess-the-sketch-cfg
+build:
+  googleCloudBuild: {}
+  tagPolicy:
+    sha256: {}
+  artifacts:
+  - image: guess-the-sketch-app
+    context: .
+manifests:
+  rawYaml:
+  - ./k8s.yaml
+deploy:
+  kubectl:
+    defaultNamespace: genai


### PR DESCRIPTION
Switches from `docker build`, `docker push` and `kubectl apply` to `skaffold run` for the guess-the-sketch example to be consistent with all of the other APIs.