### PR TITLE
 Moves Guess-the-Sketch to Imagen 2, adds option for Stable Diffusion

### DIFF
--- a/examples/guess-the-sketch/README.md
+++ b/examples/guess-the-sketch/README.md
@@ -26,3 +26,13 @@ kubectl get gs
 ```
 5. Once the GameServer is Ready, you can connect to the game through its IP Address and PORT using web browser,
 and open two pages to mock two players.
+
+### To switch from Imagen 2 back to Imagen (1)
+
+Scale the Imagen 1 deployment up and scale the Imagen 2 deployment down:
+```
+kubectl scale -ngenai deployment/vertex-image-api-imagen-1 --replicas=1
+kubectl scale -ngenai deployment/vertex-image-api-imagen-2 --replicas=0
+```
+
+(Vice-versa to switch back.)

--- a/examples/guess-the-sketch/src/app.py
+++ b/examples/guess-the-sketch/src/app.py
@@ -24,6 +24,13 @@ import os
 import swagger_client as Agones
 import threading
 
+# Uncomment to use Stable Diffusion explicitly - requires the Stable Diffusion backend, which uses a GPU:
+#   kubectl scale deployment/stable-diffusion-endpt --replicas=1 -ngenai
+# IMAGE_GENERATION_ENDPOINT="http://stable-diffusion-api.genai.svc"
+
+# Use whatever the GenAI API is routing to (default Vertex)
+IMAGE_GENERATION_ENDPOINT="http://genai-api.genai.svc/genai/image"
+
 app = Flask(__name__,
             static_folder="static")
 app.config['SECRET_KEY'] = f'{int(random.random()*100000000)}'
@@ -127,9 +134,7 @@ def handle_message(data):
     guess_payload = {
         'prompt': f'''{message}''',
     }
-    model_response = requests.post(f'http://genai-api.genai.svc/genai/image', headers=headers, json=guess_payload)
-    # stable diffusion
-    #model_response_cur = requests.post(f'http://stable-diffusion-api.genai.svc/generate', headers=headers, json=payload_cur)
+    model_response = requests.post(IMAGE_GENERATION_ENDPOINT, headers=headers, json=guess_payload)
     encoded_image = base64.b64encode(model_response.content).decode('utf-8')
     player_guess[player_id][round]['guess_picture'] = encoded_image
     # Send the guess picture to both the players, they will be shown in summary page
@@ -169,9 +174,7 @@ def handle_message(data):
     picture_generate_payload = {
         'prompt': f'''{message}''',
     }
-    model_response = requests.post(f'http://genai-api.genai.svc/genai/image', headers=headers, json=picture_generate_payload)
-    # stable diffusion
-    #model_response_cur = requests.post(f'http://stable-diffusion-api.genai.svc/generate', headers=headers, json=picture_generate_payload)
+    model_response = requests.post(IMAGE_GENERATION_ENDPOINT, headers=headers, json=picture_generate_payload)
     encoded_image = base64.b64encode(model_response.content).decode('utf-8')
     player_prompt[player_id][round]['picture'] = encoded_image
 

--- a/genai/api/genai_api/k8s.yaml
+++ b/genai/api/genai_api/k8s.yaml
@@ -56,6 +56,9 @@ spec:
           value: http://vertex-code-api.genai.svc
         - name: GENAI_IMAGE_ENDPOINT
           value: http://vertex-image-api.genai.svc
+        # If you want to route /genai/image to Stable Diffusion, use this instead:
+        # - name: GENAI_IMAGE_ENDPOINT
+        #   value: http://stable-diffusion-api.genai.svc
         - name: GENAI_NPC_CHAT_ENDPOINT
           value: http://npc-chat-api.genai.svc
         resources:

--- a/genai/api/stable_diffusion_api/src/main.py
+++ b/genai/api/stable_diffusion_api/src/main.py
@@ -35,9 +35,10 @@ STABLE_DIFFUSION_ENDPOINT = os.environ['STABLE_DIFFUSION_ENDPOINT']
 
 headers = {"Content-Type": "application/json"}
 
-
-class Payload_General(BaseModel):
+class Payload_StableDiffusion(BaseModel):
     prompt: str
+    number_of_images: int | None = 1
+    seed: int | None = None
 
 
 # Routes
@@ -51,8 +52,12 @@ async def health_check():
 @app.get("/")
 def image_gen_open_source_x_get(
         prompt: str,
+        number_of_images: int = 1,
+        seed: int = None,
     ):
     try:
+        if number_of_images > 1 or seed:
+            print('parameters seed and number_of_images not supported, ignored')
         request_payload = {
             'prompt': prompt,
         }
@@ -64,7 +69,7 @@ def image_gen_open_source_x_get(
 
 
 @app.post("/")
-def image_gen_open_source_x_post(payload: Payload_General):
+def image_gen_open_source_x_post(payload: Payload_StableDiffusion):
     try:
         request_payload = {
             'prompt': payload.prompt,

--- a/genai/api/vertex_image_api/k8s.yaml
+++ b/genai/api/vertex_image_api/k8s.yaml
@@ -46,6 +46,10 @@ spec:
         env:
         - name: ENV
           value: dev
+        - name: VERTEX_IMAGE_GENERATION_MODEL
+          value: imagegeneration@005 # Imagen 2
+          # Uncomment for original Imagen
+          # value: imagegeneration@002
         resources:
           requests:
             cpu: 100m

--- a/genai/api/vertex_image_api/k8s.yaml
+++ b/genai/api/vertex_image_api/k8s.yaml
@@ -1,9 +1,9 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: vertex-image-api
+  name: vertex-image-api-imagen-2
   labels:
-    name: vertex-image-api
+    name: vertex-image-api-imagen-2
 spec:
   replicas: 1
   strategy:
@@ -14,10 +14,12 @@ spec:
   selector:
     matchLabels:
       name: vertex-image-api
+      model: imagen-2
   template:
     metadata:
       labels:
         name: vertex-image-api
+        model: imagen-2
         version: stable
       annotations:
         instrumentation.opentelemetry.io/inject-python: "genai-instrumentation"
@@ -32,24 +34,59 @@ spec:
         - name: http
           containerPort: 8080
           protocol: TCP
-        # readinessProbe:
-        #   httpGet:
-        #     path: /health
-        #     port: http-front
-        #   initialDelaySeconds: 5
-        #   periodSeconds: 5
-        # livenessProbe:
-        #   tcpSocket:
-        #     port: http-front
-        #   initialDelaySeconds: 5
-        #   periodSeconds: 5
         env:
         - name: ENV
           value: dev
         - name: VERTEX_IMAGE_GENERATION_MODEL
           value: imagegeneration@005 # Imagen 2
-          # Uncomment for original Imagen
-          # value: imagegeneration@002
+        resources:
+          requests:
+            cpu: 100m
+            memory: 64Mi
+          limits:
+            memory: 512Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vertex-image-api-imagen-1
+  labels:
+    name: vertex-image-api-imagen-1
+spec:
+  replicas: 0
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 40%
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      name: vertex-image-api
+      model: imagen-1
+  template:
+    metadata:
+      labels:
+        name: vertex-image-api
+        model: imagen-1
+        version: stable
+      annotations:
+        instrumentation.opentelemetry.io/inject-python: "genai-instrumentation"
+    spec:
+      serviceAccountName: k8s-sa-aiplatform
+      restartPolicy: Always
+      containers:
+      - image: vertex-image-api
+        name: vertex-image-api
+        imagePullPolicy: Always
+        ports:
+        - name: http
+          containerPort: 8080
+          protocol: TCP
+        env:
+        - name: ENV
+          value: dev
+        - name: VERTEX_IMAGE_GENERATION_MODEL
+          value: imagegeneration@002 # Imagen 1
         resources:
           requests:
             cpu: 100m

--- a/genai/api/vertex_image_api/src/main.py
+++ b/genai/api/vertex_image_api/src/main.py
@@ -56,12 +56,19 @@ def get_gcp_metadata():
     return project_id, region, zone
 
 GCP_PROJECT_ID, GCP_REGION, GCP_ZONE = get_gcp_metadata()
-logging.debug(f'GCP_PROJECT_ID: {GCP_PROJECT_ID}')
-logging.debug(f'GCP_REGION:     {GCP_REGION}')
-logging.debug(f'GCP_ZONE:       {GCP_ZONE}')
+VERTEX_IMAGE_GENERATION_MODEL = os.environ['VERTEX_IMAGE_GENERATION_MODEL']
+
+logging.debug(f'GCP_PROJECT_ID:                  {GCP_PROJECT_ID}')
+logging.debug(f'GCP_REGION:                      {GCP_REGION}')
+logging.debug(f'GCP_ZONE:                        {GCP_ZONE}')
+logging.debug(f'VERTEX_IMAGE_GENERATION_MODEL:   {VERTEX_IMAGE_GENERATION_MODEL}')
+
 
 # Initialize Vertex LLM Model
-model_vertex_imagen   = Google_Cloud_Imagen(GCP_PROJECT_ID, GCP_REGION=GCP_REGION)
+model_vertex_imagen   = Google_Cloud_Imagen(
+    GCP_PROJECT_ID,
+    GCP_REGION=GCP_REGION,
+    VERTEX_IMAGE_GENERATION_MODEL=VERTEX_IMAGE_GENERATION_MODEL)
 
 headers = {"Content-Type": "application/json"}
 

--- a/genai/api/vertex_image_api/src/utils/model_util.py
+++ b/genai/api/vertex_image_api/src/utils/model_util.py
@@ -12,125 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
-import json
-import requests
+import os
 import vertexai
-from vertexai.language_models import TextGenerationModel, ChatModel, CodeGenerationModel, CodeChatModel, InputOutputTextPair
-from vertexai.preview.vision_models import Image, ImageGenerationModel
-
-
-class Google_Cloud_GenAI:
-
-    def __init__(self, GCP_PROJECT_ID, GCP_REGION,  MODEL_TYPE):
-        if GCP_PROJECT_ID=="":
-            print(f'[ WARNING ] GCP_PROJECT_ID ENV variable is empty. Be sure to set the GCP_PROJECT_ID ENV variable.')
-        
-        if GCP_REGION=="":
-            print(f'[ WARNING ] GCP_REGION ENV variable is empty. Be sure to set the GCP_REGION ENV variable.')
-
-        if MODEL_TYPE=="":
-            print(f'[ WARNING ] MODEL_TYPE ENV variable is empty. Be sure to set the MODEL_TYPE ENV variable.') 
-        
-        self.GCP_PROJECT_ID = GCP_PROJECT_ID
-        self.GCP_REGION = GCP_REGION
-        self.MODEL_TYPE = MODEL_TYPE
-        self.pretrained_model = f'{MODEL_TYPE.lower()}@001'
-
-        self.vertexai = vertexai.init(project=GCP_PROJECT_ID, location=GCP_REGION)
-        
-        if MODEL_TYPE.lower() == 'text-bison':
-            self.model = TextGenerationModel.from_pretrained(self.pretrained_model)
-        elif MODEL_TYPE.lower() == 'chat-bison':
-            self.model = ChatModel.from_pretrained(self.pretrained_model)
-        elif MODEL_TYPE.lower() == 'code-bison':
-            self.model = CodeGenerationModel.from_pretrained(self.pretrained_model)
-        elif MODEL_TYPE.lower() == 'codechat-bison':
-            self.model = CodeChatModel.from_pretrained(self.pretrained_model)
-        else:
-            # MODEL_TYPE can be "text-bison", "chat-bison", "code-bison", or "codechat-bison"
-            print(f'[ ERROR ] No MODEL_TYPE specified or MODEL_TYPE is incorrect. Expecting MODEL_TYPE ENV var of "text-bison", "chat-bison", "code-bison", or "codechat-bison".')
-            sys.exit()
-
-    def call_llm(self, prompt, temperature=0.2, max_output_tokens=256, top_p=0.8, top_k=40, context='', chat_examples=[], code_suffix=''):
-        if self.MODEL_TYPE.lower() == 'text-bison':
-            try:
-                parameters = {
-                    "temperature": temperature,  # Temperature controls the degree of randomness in token selection.
-                    "max_output_tokens": max_output_tokens, # Token limit determines the maximum amount of text output.
-                    "top_p": top_p,  # Tokens are selected from most probable to least until the sum of their probabilities equals the top_p value.
-                    "top_k": top_k,  # A top_k of 1 means the selected token is the most probable among all tokens.
-                }
-
-                response = self.model.predict(
-                    prompt,
-                    **parameters,
-                )
-                return response
-            except Exception as e:
-                print(f'[ EXCEPTION ] At call_llm for text-bison. {e}')
-                return ''
-        
-        elif self.MODEL_TYPE.lower() == 'chat-bison':
-            try:
-                '''
-                examples=[
-                    InputOutputTextPair(
-                        input_text="Who do you work for?",
-                        output_text="I work for Ned.",
-                    ),
-                    InputOutputTextPair(
-                        input_text="What do I like?",
-                        output_text="Ned likes watching movies.",
-                    ),
-                ]
-                '''
-
-                chat = self.model.start_chat(
-                    context=context,
-                    examples=chat_examples,
-                    temperature=temperature,
-                    max_output_tokens=max_output_tokens,
-                    top_p=top_p,
-                    top_k=top_k
-                )
-
-                response = chat.send_message(prompt)
-                return response
-            except Exception as e:
-                print(f'[ EXCEPTION ] At call_chat for chat-bison. {e}')
-                return ''
-        
-        elif self.MODEL_TYPE.lower() == 'code-bison':
-            '''A language model that generates code.'''
-            try:
-                response = self.model.predict(prefix=prompt, temperature=temperature, max_output_tokens=max_output_tokens, suffix=code_suffix)
-                return response
-            except Exception as e:
-                print(f'[ EXCEPTION ] At call_chat for codechat-bison. {e}')
-                return ''        
-        
-        elif self.MODEL_TYPE.lower() == 'codechat-bison':
-            '''CodeChatModel represents a model that is capable of completing code.'''
-            try:
-                code_chat = self.model.start_chat(
-                    max_output_tokens=max_output_tokens,
-                    temperature=temperature,
-                )
-
-                response = code_chat.send_message(prompt)
-                return response
-            except Exception as e:
-                print(f'[ EXCEPTION ] At call_chat for codechat-bison. {e}')
-                return ''
-
+from vertexai.preview.vision_models import ImageGenerationModel
 
 class Google_Cloud_Imagen:
     '''
     https://cloud.google.com/vertex-ai/docs/generative-ai/image/overview
     '''
 
-    def __init__(self, GCP_PROJECT_ID, GCP_REGION):
+    def __init__(self, GCP_PROJECT_ID, GCP_REGION, VERTEX_IMAGE_GENERATION_MODEL):
         if GCP_PROJECT_ID=="":
             print(f'[ WARNING ] GCP_PROJECT_ID ENV variable is empty. Be sure to set the GCP_PROJECT_ID ENV variable.')
 
@@ -141,4 +32,4 @@ class Google_Cloud_Imagen:
         self.GCP_REGION = GCP_REGION
 
         self.vertexai = vertexai.init(project=GCP_PROJECT_ID, location=GCP_REGION)
-        self.model = ImageGenerationModel.from_pretrained("imagegeneration@005")
+        self.model = ImageGenerationModel.from_pretrained(VERTEX_IMAGE_GENERATION_MODEL)

--- a/genai/api/vertex_image_api/src/utils/model_util.py
+++ b/genai/api/vertex_image_api/src/utils/model_util.py
@@ -141,4 +141,4 @@ class Google_Cloud_Imagen:
         self.GCP_REGION = GCP_REGION
 
         self.vertexai = vertexai.init(project=GCP_PROJECT_ID, location=GCP_REGION)
-        self.model = ImageGenerationModel.from_pretrained("imagegeneration@002")
+        self.model = ImageGenerationModel.from_pretrained("imagegeneration@005")

--- a/genai/image/stable_diffusion/Dockerfile
+++ b/genai/image/stable_diffusion/Dockerfile
@@ -26,10 +26,11 @@ WORKDIR /app
 # ENV vars should be passed in when starting container
 ENV MODEL_TYPE=""
 
-COPY src /app/
-
-# Install production dependencies
+# Install production dependencies. (Copy/pull requirements early to cache this layer.)
+COPY src/requirements.txt /app/
 RUN pip install --no-cache-dir -r requirements.txt
+
+COPY src /app/
 
 EXPOSE 8080
 


### PR DESCRIPTION
* Moves vertex image API to Imagen 2.
* Ensures stable-diffusion-api is identical to existing image gen API, but ignores parameters.
* Adds commented out part of genai deployment to show how to change the global routing to Stable Diffusion.
* Adds commented out part of Guess-the-Sketch to show how to cut directly to Stable Diffusion.