### PR TITLE
Move OM2 from Cloud Run to GKE

### DIFF
--- a/examples/guess-the-sketch/README.md
+++ b/examples/guess-the-sketch/README.md
@@ -31,21 +31,11 @@ presented with three predefined prompts and asked to select one of them._
    cd ${CUR_DIR:?}/examples/guess-the-sketch
    skaffold run --build-concurrency=0 --cache-artifacts=false
    ```
-1. Deploy Open Match 2 on Cloud Run by following [the documention](https://github.com/googleforgames/open-match2/blob/main/docs/DEVELOPMENT.md).
-   - NOTE: before running `gcloud run services replace service.yaml` to deploy Open Match 2, make sure to:
-      - Replace the IP address of the `OM_REDIS_WRITE_HOST` and `OM_REDIS_READ_HOST` in the [`service.yaml`](https://github.com/googleforgames/open-match2/blob/main/deploy/service.yaml) file to be the IP address of the Redis instance you created.
-      - Replace the `run.googleapis.com/network-interfaces` field to use the network and subnetwork configured by terraform. In this case, it's `vpc-genai-quickstart` and `sn-usc1`.
-      - Replace the `cloud.googleapis.com/location` field to be the location of your `sn-usc1` subnetwork (us-central1 if you followed the top level [README](https://github.com/googleforgames/GenAI-quickstart/blob/main/README.md)).
-1. Configure Open Match 2's permissions to your cluster.
-   - Create a Google Service Account in your project and give it the `Cloud Run Invoker` role.
-   - Replace the value of `iam.gke.io/gcp-service-account` of `frontend_k8s.yaml` and `director_k8s.yaml` to be the Google Service Account you created.
-   - Bind the Kubernetes Service Account in `frontend_k8s.yaml` and `director_k8s.yaml` to the Google Service Account(in the form of `SERVICE_ACCOUNT_NAME@PROJECT_ID.iam.gserviceaccount.com`) with 
+1. Deploy Open Match 2 with the following command.
    ```
-   gcloud iam service-accounts add-iam-policy-binding   --role roles/iam.workloadIdentityUser   --member "serviceAccount:PROJECT_ID.svc.id.goog[genai/frontend-sa]"   YOUR_GOOGLE_SERVICE_ACCOUNT
-
-   gcloud iam service-accounts add-iam-policy-binding   --role roles/iam.workloadIdentityUser   --member "serviceAccount:PROJECT_ID.svc.id.goog[genai/fleet-allocator]"   YOUR_GOOGLE_SERVICE_ACCOUNT
+   kubectl apply -f redis.yaml
+   kubectl apply -f om.yaml
    ```
-   - Replace the value of `OM_CORE_ADDRESS` environment variable in `frontend_k8s.yaml` and `director_k8s.yaml` to be the url of the OM2 that's deployed on Cloud Run.
 1. Install the frontend and match maker into your cluster:
    - (optional) If you want to enable the consent screen, update `examples/guess-the-sketch/matchmaker/frontend/k8s.yaml` to set `showConsentPage` to `true` before running the `skaffold` command.
    ```

--- a/examples/guess-the-sketch/matchmaker/director_k8s.yaml
+++ b/examples/guess-the-sketch/matchmaker/director_k8s.yaml
@@ -35,14 +35,12 @@ spec:
           imagePullPolicy: Always
           env:
           - name: OM_CORE_ADDRESS
-            value: YOUR_OM_CORE_URL
+            value: "http://open-match-service.default.svc.cluster.local:50504"
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: fleet-allocator
-  annotations:
-    iam.gke.io/gcp-service-account: YOUR_GOOGLE_SERVICE_ACCOUNT
   labels:
     app: fleet-allocator
     name: guess-the-sketch-director

--- a/examples/guess-the-sketch/matchmaker/frontend_k8s.yaml
+++ b/examples/guess-the-sketch/matchmaker/frontend_k8s.yaml
@@ -13,13 +13,6 @@
 # limitations under the License.
 
 ---
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: frontend-sa
-  annotations:
-    iam.gke.io/gcp-service-account: YOUR_GOOGLE_SERVICE_ACCOUNT
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -36,7 +29,6 @@ spec:
       labels:
         app: guess-the-sketch-frontend
     spec:
-      serviceAccountName: frontend-sa
       containers:
         - name: guess-the-sketch-frontend
           image: guess-the-sketch-frontend
@@ -47,7 +39,7 @@ spec:
           args: ["-showConsentPage=false"]
           env:
           - name: OM_CORE_ADDRESS
-            value: YOUR_OM_CORE_URL
+            value: "http://open-match-service.default.svc.cluster.local:50504"
 ---
 apiVersion: v1
 kind: Service

--- a/examples/guess-the-sketch/matchmaker/om.yaml
+++ b/examples/guess-the-sketch/matchmaker/om.yaml
@@ -1,0 +1,58 @@
+---
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: open-match-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: open-match-deployment
+  template:
+    metadata:
+      labels:
+        app: open-match-deployment
+    spec:
+      containers:
+        - image: us-docker.pkg.dev/open-match-public-images/open-match2/om-core
+          name: core 
+          ports:
+          - containerPort: 8080
+          env:
+          - name: OM_LOGGING_LEVEL
+            value: debug
+          - name: OM_REDIS_WRITE_HOST
+            value: redis.default.svc.cluster.local
+          - name: OM_REDIS_READ_HOST
+            value: redis.default.svc.cluster.local
+          - name: OM_OTEL_SIDECAR
+            value: "false"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: open-match-service
+  labels:
+    run: open-match-service
+spec:
+  ports:
+    - port: 50504
+      targetPort: 8080
+      protocol: TCP
+  selector:
+    app: open-match-deployment
+  type: ClusterIP

--- a/examples/guess-the-sketch/matchmaker/omclient/omclient.go
+++ b/examples/guess-the-sketch/matchmaker/omclient/omclient.go
@@ -586,31 +586,25 @@ func (rc *RestfulOMGrpcClient) Post(ctx context.Context, logger *logrus.Entry, u
 
 	postLogger.Trace("Header set, request created")
 
-	// if os.Getenv("K_REVISION") != "" { // Running on Cloud Run, get GCP SA token
-	if rc.tokenSource == nil {
-		// Create a TokenSource if none exists.
-		rc.tokenSource, err = idtoken.NewTokenSource(ctx, url)
-		if err != nil {
-			fmt.Println("Cloud Run service account authentication requires token source, but couldn't get one. Trying to continue without SA auth. idtoken.NewTokenSource: %w", err)
+	fmt.Println("running new version000")
+	if os.Getenv("K_REVISION") != "" { // Running on Cloud Run, get GCP SA token
+		if rc.tokenSource == nil {
+			// Create a TokenSource if none exists.
+			rc.tokenSource, err = idtoken.NewTokenSource(ctx, url)
+			if err != nil {
+				err = fmt.Errorf("cloud Run service account authentication requires token source, but couldn't get one. idtoken.NewTokenSource: %v", err)
+				return nil, err
+			}
 		}
-	}
 
-	if rc.tokenSource == nil {
-		fmt.Println("rc.tokenSource is nil")
+		// Retrieve an identity token. Will reuse tokens until refresh needed.
+		token, err := rc.tokenSource.Token()
+		if err != nil {
+			err = fmt.Errorf("cloud Run service account authentication requires a token, but couldn't get one. TokenSource.Token: %v", err)
+			return nil, err
+		}
+		token.SetAuthHeader(req)
 	}
-
-	// Retrieve an identity token. Will reuse tokens until refresh needed.
-	token, err := rc.tokenSource.Token()
-	if err != nil {
-		fmt.Println("Cloud Run service account authentication requires a token, but couldn't get one. Trying to continue without SA auth. TokenSource.Token: %w", err)
-	}
-	token.SetAuthHeader(req)
-	// }
-
-	// client, err := idtoken.NewClient(ctx, url)
-	// if err != nil {
-	// 	fmt.Println("Error connecting to client: ", err)
-	// }
 
 	// Log all request headers if debug logging (slow)
 	if logrus.IsLevelEnabled(logrus.DebugLevel) {

--- a/examples/guess-the-sketch/matchmaker/redis.yaml
+++ b/examples/guess-the-sketch/matchmaker/redis.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+spec:
+  selector:
+    matchLabels:
+      app: redis
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+      - name: redis
+        image: redis:latest
+        ports:
+        - containerPort: 6379
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 1000m
+            memory: 1Gi
+        volumeMounts:
+        - name: redis-storage
+          mountPath: /data
+      volumes:
+      - name: redis-storage
+        emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+spec:
+  selector:
+    app: redis
+  ports:
+  - port: 6379
+    targetPort: 6379
+  type: ClusterIP


### PR DESCRIPTION
Move OM2 from running on Cloud Run to running on GKE. This requires simpler setup because there's no need to configure permissions for GKE services to communicate with Cloud Run services.